### PR TITLE
chore: Deploy every night

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,12 @@
+name: Netlify Deploy
+
+on:
+  schedule:
+  - cron: "0 15 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Netlify Hook
+      run: curl -X POST ${{ secrets.netlify_build_url }}


### PR DESCRIPTION
This adds a GitHub workflow to run every night to regenerate the site (and thus, pull in the latest data)