### PR TITLE
docs: make further weekly downloads numbers dynamic

### DIFF
--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -76,7 +76,7 @@ eleventyExcludeFromCollections: true
         <header class="section-head center-text">
             <h2 class="section-title h3">The pluggable linting utility for JavaScript and JSX</h2>
             <p class="section-supporting-text fs-step-0">
-                ESLint is an open source project that helps developers find and fix problems with their code. It's the #1 JavaScript linter by downloads on NPM, with over 6.5 million per week.
+                ESLint is an open source project that helps developers find and fix problems with their code. It's the #1 JavaScript linter by downloads on NPM, with over {{ stats.weeklyDownloads | shortNumber }} million per week.
             </p>
         </header>
         <div class="section-body features-wrapper grid">
@@ -170,7 +170,7 @@ eleventyExcludeFromCollections: true
         <header class="section-head center-text">
             <h2 class="section-title h3">Welcome to the community</h2>
             <p class="section-supporting-text fs-step-0">
-                ESLint is the #1 JavaScript linter by downloads on npm (over 6.5M downloads / week) and is used at companies like Microsoft, Airbnb, Netflix, and Facebook.
+                ESLint is the #1 JavaScript linter by downloads on npm (over {{ stats.weeklyDownloads | shortNumber }} downloads / week) and is used at companies like Microsoft, Airbnb, Netflix, and Facebook.
             </p>
         </header>
         <div class="metrics center-text">


### PR DESCRIPTION
I haven't confirmed this by attempting a build, but I think you want it dynamic like this as presumably one wishes the site to tout the newer 23.5 million over the currently listed 6.5 million.