### PR TITLE
fix: og:image

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% set page_title = [title, " - ESLint - Pluggable JavaScript Linter"] | join %}
-    {% set cover_image = "/icon.svg" %}
+    {% set cover_image = "https://new.eslint.org/icon-512.png" %}
     {% set cover_image_alt = "ESLint logo" %}
     {% set page_desc = "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease." %}
 


### PR DESCRIPTION
`og:image` is url, not path.
https://ogp.me/
SVG is not supported at twitter card.
https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image