### PR TITLE
fix: Clean up text on homepage and reduce duplication

### DIFF
--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -76,7 +76,7 @@ eleventyExcludeFromCollections: true
         <header class="section-head center-text">
             <h2 class="section-title h3">The pluggable linting utility for JavaScript and JSX</h2>
             <p class="section-supporting-text fs-step-0">
-                ESLint is an open source project that helps developers find and fix problems with their code. It's the #1 JavaScript linter by downloads on NPM, with over {{ stats.weeklyDownloads | shortNumber }} million per week.
+                ESLint is an open source project that helps developers find and fix problems with their JavaScript code. It doesn't matter if you're writing JavaScript in the browser or on the server, with or without a framework, ESLint can help your code live its best life.
             </p>
         </header>
         <div class="section-body features-wrapper grid">


### PR DESCRIPTION
We were duplicating the same sentence in two places, so I changed one to something different.