### PR TITLE
feat: increase tappable area on mobile nav links

### DIFF
--- a/src/assets/css/components/navigation.css
+++ b/src/assets/css/components/navigation.css
@@ -28,7 +28,8 @@
   .site-nav a:not(.c-btn) {
     text-decoration: none;
     color: inherit;
-    transition: color .2s linear; }
+    transition: color .2s linear;
+    display: block; }
     .site-nav a:not(.c-btn):hover {
       color: var(--link-color); }
   .site-nav a:not(.c-btn)[data-current="page"],

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1761,7 +1761,8 @@ a.c-btn {
   .site-nav a:not(.c-btn) {
     text-decoration: none;
     color: inherit;
-    transition: color .2s linear; }
+    transition: color .2s linear;
+    display: block; }
     .site-nav a:not(.c-btn):hover {
       color: var(--link-color); }
   .site-nav a:not(.c-btn)[data-current="page"],

--- a/src/assets/scss/components/navigation.scss
+++ b/src/assets/scss/components/navigation.scss
@@ -11,8 +11,6 @@
         font-size: var(--step-1);
         margin-top: 1rem;
         margin-block-start: 1rem;
-        // display: flex;
-        // flex-direction: column;
 
         @media all and (min-width: 680px) {
             font-size: var(--step-0);
@@ -44,6 +42,7 @@
         text-decoration: none;
         color: inherit;
         transition: color .2s linear;
+        display: block;
 
         &:hover {
             color: var(--link-color);


### PR DESCRIPTION
I noticed the navigation links don't take up the entire width on  mobile, so I made them so in order to increase the tappable area.