### PR TITLE
chore: More efficient donations fetch script

### DIFF
--- a/src/_data/donations.json
+++ b/src/_data/donations.json
@@ -1,191 +1,263 @@
 [
     {
-        "id": "03e9bd51-7972-4e5d-949d-76eceaa722b7",
+        "id": "eng0kzdy-vor4pzb0-oxopbma8-37xlw95j",
+        "name": "Wanda",
+        "url": null,
+        "image": "https://images.opencollective.com/guest-7dcb08ec/avatar.png",
+        "amount": 3,
+        "date": "2022-02-21T11:46:53.444Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "zaxon793-jy8gpl39-mmrpbrkd-emwl5v04",
         "name": "Etsy Open Source",
         "url": null,
         "image": "https://images.opencollective.com/etsy-open-source/logo.png",
         "amount": 10000,
-        "date": "2022-01-26T17:38:53.352Z",
+        "date": "2022-01-26T17:38:53.359Z",
         "source": "opencollective"
     },
     {
-        "id": "b62c91d9-aae9-4db3-bae3-c87d9e0a0e94",
+        "id": "v349mrwg-z75lpy7d-v3gpa08d-jeybknox",
         "name": "Etsy Open Source",
         "url": null,
         "image": "https://images.opencollective.com/etsy-open-source/logo.png",
         "amount": 8000,
-        "date": "2022-01-26T13:02:20.572Z",
+        "date": "2022-01-26T13:02:20.578Z",
         "source": "opencollective"
     },
     {
-        "id": "5c6b46f2-1fd2-411c-a6a1-770a0fed33fc",
+        "id": "ywz9j4av-god8pgma-xy5pmr35-nxklb0e7",
         "name": "Guest",
         "url": null,
         "image": "https://images.opencollective.com/guest-55aa8761/avatar.png",
         "amount": 5,
-        "date": "2022-01-21T15:56:23.349Z",
+        "date": "2022-01-21T15:56:23.448Z",
         "source": "opencollective"
     },
     {
-        "id": "f8c27c78-5acb-4f09-a0ba-1aca8db4a07b",
+        "id": "3kzxy4v0-7wlr6mvl-r5e6mj9n-o8agdbe5",
         "name": "Riyadh Al Nur",
         "url": "https://twitter.com/riyadhalnur",
         "image": "https://images.opencollective.com/riyadhalnur/c7f31ce/avatar.png",
         "amount": 20,
-        "date": "2022-01-19T16:51:32.028Z",
+        "date": "2022-01-19T16:51:32.065Z",
         "source": "opencollective"
     },
     {
-        "id": "0ee57b91-fa64-497c-b08f-39a980fa52a0",
+        "id": "mvrwng4k-j03dpbm5-9ozqz57o-yl9e8xba",
         "name": "neuland - Büro für Informatik",
         "url": "https://www.neuland-bfi.de/",
         "image": "https://images.opencollective.com/neuland/1dc766b/logo.png",
         "amount": 26.94,
-        "date": "2022-01-14T10:29:57.716Z",
+        "date": "2022-01-14T10:29:57.729Z",
         "source": "opencollective"
     },
     {
-        "id": "0103cd26-5a22-42fd-81f0-376c1f9a16f1",
+        "id": "vrgbk357-l4x96ea4-7lapomew-a0jdyzn8",
         "name": "Sebastian Ramirez",
         "url": null,
         "image": "https://images.opencollective.com/sebastian-ramirez/b103023/avatar.png",
         "amount": 20,
-        "date": "2022-01-13T20:40:26.244Z",
+        "date": "2022-01-13T20:40:26.261Z",
         "source": "opencollective"
     },
     {
-        "id": "d2904289-1df7-4a16-84b0-da48a45ee856",
+        "id": "eng0kzdy-vor4pzb0-xegpbma8-37xlw95j",
         "name": "Kamino Ryo",
         "url": null,
         "image": "https://images.opencollective.com/kaminoryo/d1d9ff5/avatar.png",
         "amount": 30,
-        "date": "2022-01-09T05:22:20.369Z",
+        "date": "2022-01-09T05:22:20.377Z",
         "source": "opencollective"
     },
     {
-        "id": "641faeb1-9b0a-4053-9e22-80d1135a6702",
+        "id": "gnxdwzj3-le5mpwj8-bzjqy8rv-bko04a97",
         "name": "Mautic",
         "url": "https://www.mautic.org",
         "image": "https://images.opencollective.com/mautic/fc1aa27/logo.png",
         "amount": 200,
-        "date": "2022-01-07T11:40:17.623Z",
+        "date": "2022-01-07T11:40:17.632Z",
         "source": "opencollective"
     },
     {
-        "id": "03e9bd51-7972-4e5d-949d-76eceaa722b7",
-        "name": "Etsy Open Source",
-        "url": null,
-        "image": "https://images.opencollective.com/etsy-open-source/logo.png",
-        "amount": 10000,
-        "date": "2022-01-26T17:38:53.352Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "b62c91d9-aae9-4db3-bae3-c87d9e0a0e94",
-        "name": "Etsy Open Source",
-        "url": null,
-        "image": "https://images.opencollective.com/etsy-open-source/logo.png",
-        "amount": 8000,
-        "date": "2022-01-26T13:02:20.572Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "5c6b46f2-1fd2-411c-a6a1-770a0fed33fc",
-        "name": "Guest",
-        "url": null,
-        "image": "https://images.opencollective.com/guest-55aa8761/avatar.png",
-        "amount": 5,
-        "date": "2022-01-21T15:56:23.349Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "f8c27c78-5acb-4f09-a0ba-1aca8db4a07b",
-        "name": "Riyadh Al Nur",
-        "url": "https://twitter.com/riyadhalnur",
-        "image": "https://images.opencollective.com/riyadhalnur/c7f31ce/avatar.png",
-        "amount": 20,
-        "date": "2022-01-19T16:51:32.028Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "0ee57b91-fa64-497c-b08f-39a980fa52a0",
-        "name": "neuland - Büro für Informatik",
-        "url": "https://www.neuland-bfi.de/",
-        "image": "https://images.opencollective.com/neuland/1dc766b/logo.png",
-        "amount": 26.94,
-        "date": "2022-01-14T10:29:57.716Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "0103cd26-5a22-42fd-81f0-376c1f9a16f1",
-        "name": "Sebastian Ramirez",
-        "url": null,
-        "image": "https://images.opencollective.com/sebastian-ramirez/b103023/avatar.png",
-        "amount": 20,
-        "date": "2022-01-13T20:40:26.244Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "d2904289-1df7-4a16-84b0-da48a45ee856",
-        "name": "Kamino Ryo",
-        "url": null,
-        "image": "https://images.opencollective.com/kaminoryo/d1d9ff5/avatar.png",
-        "amount": 30,
-        "date": "2022-01-09T05:22:20.369Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "641faeb1-9b0a-4053-9e22-80d1135a6702",
-        "name": "Mautic",
-        "url": "https://www.mautic.org",
-        "image": "https://images.opencollective.com/mautic/fc1aa27/logo.png",
-        "amount": 200,
-        "date": "2022-01-07T11:40:17.623Z",
-        "source": "opencollective"
-    },
-    {
-        "id": "cb2b3c44-bcdf-41e6-9a2b-ec9217090ed1",
+        "id": "jrkx5lmn-v904qjwz-xxmp8bwa-7zdygoe3",
         "name": "Algolia",
         "url": "https://algolia.com",
         "image": "https://images.opencollective.com/algolia/d69b553/logo.png",
         "amount": 3000,
-        "date": "2022-01-04T19:58:03.143Z",
+        "date": "2022-01-04T19:58:03.201Z",
         "source": "opencollective"
     },
     {
-        "id": "bfd0ecdc-95a2-4a28-b592-cfb3afcd8e1d",
+        "id": "n4gx0bro-v5m96n0e-4rwqd8lk-3ey7jzwa",
         "name": "OAK'S LAB",
         "url": "https://www.oakslab.com/",
         "image": "https://images.opencollective.com/oaks-lab/6182cde/logo.png",
         "amount": 112,
-        "date": "2021-12-21T17:18:13.671Z",
+        "date": "2021-12-21T17:18:13.685Z",
         "source": "opencollective"
     },
     {
-        "id": "74d17763-8913-43d0-b634-bbea0596aaee",
+        "id": "jrkx5lmn-v904qjwz-z3kp8bwa-7zdygoe3",
         "name": "Red Hat",
         "url": "https://www.redhat.com",
         "image": "https://images.opencollective.com/redhat/f51710e/logo.png",
         "amount": 3000,
-        "date": "2021-12-14T22:29:21.185Z",
+        "date": "2021-12-14T22:29:21.196Z",
         "source": "opencollective"
     },
     {
-        "id": "172d9015-f83d-4ece-b9f8-3a20b130060f",
+        "id": "gnxdwzj3-le5mpwjm-398qy8rv-bko04a97",
         "name": "konaktiva",
         "url": null,
         "image": "https://images.opencollective.com/konaktiva/avatar.png",
         "amount": 54.08,
-        "date": "2021-12-07T14:28:10.066Z",
+        "date": "2021-12-07T14:28:10.086Z",
         "source": "opencollective"
     },
     {
-        "id": "fd67b5f8-6de5-4520-9122-8082b6adfb7b",
+        "id": "eng0kzdy-vor4pzbm-ge9pbma8-37xlw95j",
         "name": "Guest",
         "url": null,
         "image": "https://images.opencollective.com/guest-a1864cc3/avatar.png",
         "amount": 25,
-        "date": "2021-12-04T05:05:25.618Z",
+        "date": "2021-12-04T05:05:25.626Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "n4gx0bro-v5m96n0e-gayqd8lk-3ey7jzwa",
+        "name": "dtc innovation",
+        "url": null,
+        "image": "https://images.opencollective.com/dtc-innovation/logo.png",
+        "amount": 513.09,
+        "date": "2021-12-01T11:36:39.222Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "mvrwng4k-j03dpbm8-o8lqz57o-yl9e8xba",
+        "name": "Dolphin{anty}",
+        "url": "https://anty.dolphin.ru.com",
+        "image": "https://images.opencollective.com/dolphin/056c63f/avatar.png",
+        "amount": 50,
+        "date": "2021-11-16T08:30:14.041Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "3k0exgzn-m8yj64rw-mn9p5wao-9r7b4dlv",
+        "name": "Jared Musil",
+        "url": "https://jaredmusil.com",
+        "image": "https://images.opencollective.com/jared-musil/6a972d3/avatar.png",
+        "amount": 5,
+        "date": "2021-11-06T21:10:59.783Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "vrgbk357-l4x96ea0-7vjpomew-a0jdyzn8",
+        "name": "dtc innovation",
+        "url": null,
+        "image": "https://images.opencollective.com/dtc-innovation/logo.png",
+        "amount": 520,
+        "date": "2021-10-20T10:02:24.800Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "8k03reyd-5agmq5ej-97kqlbwo-z7j4nxv9",
+        "name": "Carl Jamilkowski",
+        "url": "http://www.okcarl.com/",
+        "image": "https://images.opencollective.com/carl-jamilkowski/dee6905/avatar.png",
+        "amount": 5,
+        "date": "2021-09-26T19:05:10.764Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "3k0exgzn-m8yj64rk-l57p5wao-9r7b4dlv",
+        "name": "Oliver Tacke",
+        "url": null,
+        "image": "https://images.opencollective.com/guest-cfbe3557/avatar.png",
+        "amount": 10,
+        "date": "2021-09-21T09:37:10.725Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "vedj9wro-z3a56d3o-argp7blg-8x4m0ykn",
+        "name": "Adarsh Jain",
+        "url": null,
+        "image": "https://images.opencollective.com/adarsh-jain/b2bdfcb/avatar.png",
+        "amount": 10,
+        "date": "2021-08-31T08:18:07.401Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "mlo94zn7-x08dpob8-b43qewga-3vjbrky5",
+        "name": "Jeroen Bloemscheer",
+        "url": null,
+        "image": "https://images.opencollective.com/guest-241dc697/avatar.png",
+        "amount": 5,
+        "date": "2021-08-24T10:01:04.341Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "mywxoz34-09rl6kgk-074pvenb-dj7gk85a",
+        "name": "Chaim Krause",
+        "url": null,
+        "image": "https://images.opencollective.com/chaim-krause/ebcfd02/avatar.png",
+        "amount": 10,
+        "date": "2021-08-21T00:24:33.807Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "rvedj9wr-oz3a56dw-9rzq7blg-8x4m0ykn",
+        "name": "Ryan Chartrand",
+        "url": null,
+        "image": "https://images.opencollective.com/ryanchartrand/28588c0/avatar.png",
+        "amount": 50,
+        "date": "2021-07-07T10:53:16.796Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "rvedj9wr-oz3a56dn-o5aq7blg-8x4m0ykn",
+        "name": "Cybozu, Inc.",
+        "url": "https://cybozu.co.jp/",
+        "image": "https://images.opencollective.com/cybozu/933e46d/logo.png",
+        "amount": 1729,
+        "date": "2021-06-30T06:13:40.220Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "x8k03rey-d5agmq5g-jab6lbwo-z7j4nxv9",
+        "name": "slideshowp2's blog",
+        "url": null,
+        "image": "https://images.opencollective.com/slideshowp2/logo.png",
+        "amount": 1,
+        "date": "2021-06-30T02:25:02.532Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "53kzxy4v-07wlr6ml-zjmpmj9n-o8agdbe5",
+        "name": "AMP Project",
+        "url": "https://www.ampproject.org/",
+        "image": "https://images.opencollective.com/amp/c8a3b25/logo.png",
+        "amount": 7500,
+        "date": "2021-06-21T16:46:40.817Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "53kzxy4v-07wlr6ml-r37pmj9n-o8agdbe5",
+        "name": "EY Doberman",
+        "url": "https://doberman.co",
+        "image": "https://images.opencollective.com/ey-doberman/b269462/logo.png",
+        "amount": 827,
+        "date": "2021-06-18T09:30:20.166Z",
+        "source": "opencollective"
+    },
+    {
+        "id": "88rzownx-l9e50pxe-yz3qymvb-dgk7j43a",
+        "name": "38elements",
+        "url": "https://japanese-document.github.io/react-redux/connect.html",
+        "image": "https://images.opencollective.com/38elements/5dfbefe/avatar.png",
+        "amount": 10,
+        "date": "2021-06-10T13:50:21.588Z",
         "source": "opencollective"
     },
     {

--- a/src/_data/sponsors.json
+++ b/src/_data/sponsors.json
@@ -1,8 +1,8 @@
 {
     "totals": {
-        "annualDonations": 147948,
-        "monthlyDonations": 12329,
-        "sponsorCount": 179
+        "annualDonations": 148100.04,
+        "monthlyDonations": 12341.67,
+        "sponsorCount": 182
     },
     "platinum": [
         {
@@ -147,7 +147,7 @@
         {
             "name": "Practice Ignition",
             "image": "https://avatars.githubusercontent.com/u/5753491?v=4",
-            "url": "https://www.practiceignition.com",
+            "url": "https://www.ignitionapp.com",
             "monthlyDonation": 200,
             "source": "github",
             "tier": "bronze-sponsor"
@@ -235,8 +235,8 @@
         },
         {
             "name": "Paul Foryt",
-            "image": "https://avatars.githubusercontent.com/u/7229568?u=83de695a7883740cb9e882150bc2618da0395771&v=4",
-            "url": "http://www.goforyt.com",
+            "image": "https://avatars.githubusercontent.com/u/7229568?u=479eec3115957259c1a11cc5093d2b3244d94e6c&v=4",
+            "url": "https://foryt.com",
             "monthlyDonation": 25,
             "source": "github",
             "tier": "backer"
@@ -421,9 +421,9 @@
             "tier": "backer"
         },
         {
-            "name": "Kamal Mukkamala",
+            "name": "Kamal",
             "image": "https://avatars.githubusercontent.com/u/12810203?v=4",
-            "url": "https://kamalnrf.com",
+            "url": "https://github.com/Kamalnrf",
             "monthlyDonation": 10,
             "source": "github",
             "tier": "backer"
@@ -1081,17 +1081,17 @@
             "tier": "backer"
         },
         {
-            "name": "Maarten Van Hoof",
-            "image": "https://avatars.githubusercontent.com/u/2543633?u=b4bd36605dd71a3213acdb5d9d2ff27216d9c7a4&v=4",
-            "url": "mrtnvh.com",
+            "name": "Dan",
+            "image": "https://avatars.githubusercontent.com/u/2481552?v=4",
+            "url": "https://danminkevitch.com",
             "monthlyDonation": 5,
             "source": "github",
             "tier": "backer"
         },
         {
-            "name": "Andrew LeTourneau",
-            "image": "https://avatars.githubusercontent.com/u/2807807?v=4",
-            "url": "https://andyletourneau.com",
+            "name": "Maarten Van Hoof",
+            "image": "https://avatars.githubusercontent.com/u/2543633?u=b4bd36605dd71a3213acdb5d9d2ff27216d9c7a4&v=4",
+            "url": "mrtnvh.com",
             "monthlyDonation": 5,
             "source": "github",
             "tier": "backer"
@@ -1212,6 +1212,14 @@
             "name": "Roman Eckert",
             "image": "https://avatars.githubusercontent.com/u/9392031?u=18c737b16bba6a4373b9b2dc63f7609819dfb5bb&v=4",
             "url": "https://github.com/romaneckert",
+            "monthlyDonation": 5,
+            "source": "github",
+            "tier": "backer"
+        },
+        {
+            "name": "mizdra",
+            "image": "https://avatars.githubusercontent.com/u/9639995?u=dd5dac271b000f6c7883880c1796ce2a95a971b2&v=4",
+            "url": "https://mizdra.net",
             "monthlyDonation": 5,
             "source": "github",
             "tier": "backer"
@@ -1361,6 +1369,14 @@
             "tier": "backer"
         },
         {
+            "name": "tera_ny",
+            "image": "https://avatars.githubusercontent.com/u/33125821?u=e2911b49e3bf868390ded98f56a4ef0843eb812b&v=4",
+            "url": "https://zenn.dev/tera_ny",
+            "monthlyDonation": 5,
+            "source": "github",
+            "tier": "backer"
+        },
+        {
             "name": "Jonas Wanner",
             "image": "https://avatars.githubusercontent.com/u/38656104?u=a4130fab0577a0a2eaa5d667114ccd2e7207aeb4&v=4",
             "url": "https://wanner.work",
@@ -1432,6 +1448,15 @@
             "totalDonations": 118,
             "source": "opencollective",
             "tier": "backer"
+        },
+        {
+            "name": "Matt Welke",
+            "url": "https://mattwelke.com",
+            "image": "https://images.opencollective.com/mattwelke/avatar.png",
+            "monthlyDonation": 2.67,
+            "totalDonations": 2.67,
+            "source": "opencollective",
+            "tier": null
         },
         {
             "name": "Shunfan Du",


### PR DESCRIPTION
This just updates the script to fetch one-time donations to use the new Open Collective API for doing so. Instead of making multiple requests and filtering, we can now just request the one-time donations directly. :tada: