### PR TITLE
chore: Update robots.txt to allow crawling

### DIFF
--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -1,5 +1,6 @@
 {
     "lang": "en",
     "locale": "en-US",
-    "version": "7.26.0"
+    "version": "7.26.0",
+    "hostname": "eslint.org"
 }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     {% set page_title = [title, " - ESLint - Pluggable JavaScript Linter"] | join %}
-    {% set cover_image = "https://new.eslint.org/icon-512.png" %}
+    {% set cover_image = ["https://", config.hostname, "/icon-512.png"] | join %}
     {% set cover_image_alt = "ESLint logo" %}
     {% set page_desc = "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease." %}
 
@@ -17,7 +17,7 @@
     {%- if original -%}
     <link rel="canonical" href="{{ original.url }}">
     {%- else -%}
-    <link rel="canonical" href="https://eslint.org{{ page.url | url }}">
+    <link rel="canonical" href="https://{{ config.hostname }}{{ page.url | url }}">
     {%- endif -%}
 
     <!-- favicon -->

--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -3,6 +3,5 @@ layout: false
 permalink: robots.txt
 eleventyExcludeFromCollections: true
 ---
-Sitemap: {{ metadata.url }}/sitemap.xml
+Sitemap: {{ config.hostname }}/sitemap.xml
 User-agent: *
-Disallow: /

--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -3,5 +3,5 @@ layout: false
 permalink: robots.txt
 eleventyExcludeFromCollections: true
 ---
-Sitemap: {{ config.hostname }}/sitemap.xml
+Sitemap: https://{{ config.hostname }}/sitemap.xml
 User-agent: *


### PR DESCRIPTION
Resets robots.txt to allow crawling. We should not merge this until we are ready to go live and retire the old website, so settings as a draft to avoid accidental merging.

Fixes #136