### PR TITLE
fix: Only load search.js when search input is there

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -110,7 +110,9 @@
         }
     </script>
     <script src="{{ '/assets/js/themes.js' | url }}"></script>
+    {%- if (hook == "blog-page") -%}
     <script type="module" src="{{ '/assets/js/search.js' | url }}"></script>
+    {%- endif -%}
     <link rel="stylesheet" type="text/css" href="{{ '/assets/css/styles.css' | url }}">
 </head>
 


### PR DESCRIPTION
We were loading `search.js` on all pages, but that caused an error because (unlike the docs site) we don't have a search box on every page.