### PR TITLE
fix: invert Github logo in dark mode

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1358,6 +1358,10 @@ ul.donations-list {
     .donation-plan__header img {
       width: 3rem; } }
 
+[data-theme="dark"] .donation-plan__github-logo {
+  -webkit-filter: invert(100%);
+  filter: invert(100%); }
+
 ul.donation-plan__features {
   flex: 1; }
   ul.donation-plan__features li {

--- a/src/assets/scss/donations.scss
+++ b/src/assets/scss/donations.scss
@@ -116,6 +116,13 @@ ul.donations-list {
     }
 }
 
+.donation-plan__github-logo {
+    [data-theme="dark"] & {
+        -webkit-filter: invert(100%);
+        filter: invert(100%);
+    }
+}
+
 ul.donation-plan__features {
     flex: 1;
 

--- a/src/content/pages/donate.md
+++ b/src/content/pages/donate.md
@@ -99,7 +99,7 @@ month to help us out." %}
             </article>
             <article class="donation-plan span-7-12">
                 <header class="donation-plan__header divider">
-                    <img src="../../assets/images/icons/github-img.svg" width="64" height="64" alt="GitHub Sponsors" />
+                    <img src="../../assets/images/icons/github-img.svg" width="64" height="64" alt="GitHub Sponsors" class="donation-plan__github-logo"/>
                     <div class="donation-plan__platform">
                         <h3 class="donation-plan__platform-name">GitHub Sponsors</h3>
                         <p class="donation-plan__description">Advanced features and reporting.</p>


### PR DESCRIPTION
Fixes #132 