### PR TITLE
chore: fix layout shift

### DIFF
--- a/src/assets/scss/components/carbon-ads.scss
+++ b/src/assets/scss/components/carbon-ads.scss
@@ -9,6 +9,13 @@
     padding: initial;
 }
 
+.carbon-wrapper {
+    height: 290px;
+    @media all and (max-width: 800px) {
+        display: none !important;
+    }
+}
+
 #carbonads {
     display: inline-block;
     margin: 2rem 0;;

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -44,7 +44,9 @@ eleventyExcludeFromCollections: true
             </div>
         </div>
         <div class="span-10-12 eslint-versions-col">
-            {% include "partials/carbon-ad.html" %}
+            <div class="carbon-wrapper">
+                {% include "partials/carbon-ad.html" %}
+            </div>
             <dl class="eslint-versions" aria-labelledby="eslint-versions-title">
                 <span id="eslint-versions-title" hidden>{{ site.homepage.versions.title }}</span>
                 <dt>{{ site.homepage.versions.latest }}</dt>


### PR DESCRIPTION
Avoids shifting content to the bottom when the ad pops up

Before:

https://user-images.githubusercontent.com/32865581/158005633-f1ff5ccd-1d90-457b-b747-357213d97591.mov

After:


https://user-images.githubusercontent.com/32865581/158005690-01cbb6c3-dc0e-4cf6-9a50-c244d496bd00.mov



