### PR TITLE
fix: remove homepage horizontal overflow on mobile

### DIFF
--- a/src/assets/scss/homepage.scss
+++ b/src/assets/scss/homepage.scss
@@ -1,3 +1,7 @@
+.homepage {
+    overflow-x: hidden;
+}
+
 .problems {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
This fixes the horizontal scrolling on mobile on the homepage. I reproduced on Safari mobile on iOS 15.3.1.

This was due to the cursor overflowing to the right. I fixed it by adding an `overflow-y: hidden` to the home page.

I'm happy to amend if you think this should be fixed differently 😊

**Before:**
<img width="445" alt="image" src="https://user-images.githubusercontent.com/4410247/158013104-dbcfbc0a-f082-461a-a5ac-51179101015b.png">

**After:**
<img width="446" alt="image" src="https://user-images.githubusercontent.com/4410247/158013131-441f58ec-03a4-4184-b772-15ac39ebfae1.png">
