### PR TITLE
chore: Fixes layout shift in mobile caused due to topnav

### DIFF
--- a/src/_includes/components/navigation.html
+++ b/src/_includes/components/navigation.html
@@ -9,7 +9,7 @@
             </svg>
         </button>
     </div>
-    <ul id="nav-list">
+    <ul id="nav-list" data-open="false">
         {% for item in site.navigation %}
         <li>
             {% set itemLink = links[item.link] %}


### PR DESCRIPTION
Lighthouse scores improved as well

Before:

https://user-images.githubusercontent.com/32865581/158770541-db2818f9-9b66-4ae9-a289-ec22d84b96b9.mov

After:


https://user-images.githubusercontent.com/32865581/158770834-482c4560-0f68-4d26-aa31-dbdd66199d0d.mov



No shifts at all