### PR TITLE
Fix typo in branding page

### DIFF
--- a/src/_data/sites/en.yml
+++ b/src/_data/sites/en.yml
@@ -131,7 +131,7 @@ branding_page:
       title: Name
       description: >
         ESLint must be written with a capital E, S and L when used, as “ES” stands 
-        for ECMAScript and “L” being the start of the world “Lint”.
+        for ECMAScript and “L” being the start of the word “Lint”.
     logo:
       title: Logo
       description:


### PR DESCRIPTION
Just a mistake I noticed while translating the file.