### PR TITLE
chore: Simplify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "_site"
-  command = "npm run fetch && npm run build"
+  command = "npm run build"
 
 # fix avif loading in Firefox
 # Source: https://reachlightspeed.com/blog/using-the-new-high-performance-avif-image-format-on-the-web-today/


### PR DESCRIPTION
Now that we have a data fetch [running nightly](https://github.com/eslint/new.eslint.org/blob/main/.github/workflows/data-fetch.yml), we don't need to do a data fetch at build time.

This will reduce our Netlify build minutes (of which we do have a limit), which will be helpful as we continue to add new translation sites.