### PR TITLE
fix: robots.txt URL

### DIFF
--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -3,6 +3,6 @@ layout: false
 permalink: robots.txt
 eleventyExcludeFromCollections: true
 ---
-Sitemap: {{ metadata.url }}/sitemap.xml
+Sitemap: https://{{ site.hostname }}/sitemap.xml
 User-agent: *
 Disallow: /


### PR DESCRIPTION
The robots.txt file needs a fully-qualified URL. We were generating an invalid robots.txt file because `metadata.url` was not defined.