### PR TITLE
fix: Ensure search only searches blog posts

### DIFF
--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -34,7 +34,7 @@ const searchClearBtn = document.querySelector('#search__clear-btn');
  */
 function fetchSearchResults(query) {
     return index.search(query, {
-        // facetFilters: ["tags:docs"]
+        filters: "blog"
     }).then(({ hits }) => hits);
 }
 

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -71,8 +71,8 @@ function displaySearchResults(results) {
             const listItem = document.createElement('li');
             listItem.classList.add('search-results__item');
             listItem.innerHTML = `
-                <h2 class="search-results__item__title"><a href="${result.url}">${result.hierarchy.lvl0}</a></h2>
-                <p class="search-results__item__context">${result._highlightResult.hierarchy.lvl0.value}</p>
+                <h2 class="search-results__item__title"><a href="${result.url}">${result.hierarchy.lvl1}</a></h2>
+                <p class="search-results__item__context">${result._highlightResult.hierarchy.lvl1.value}</p>
             `.trim();
             list.append(listItem);
         }

--- a/src/assets/js/search.js
+++ b/src/assets/js/search.js
@@ -34,7 +34,7 @@ const searchClearBtn = document.querySelector('#search__clear-btn');
  */
 function fetchSearchResults(query) {
     return index.search(query, {
-        filters: "blog"
+        facetFilters: ["tags:blog"]
     }).then(({ hits }) => hits);
 }
 


### PR DESCRIPTION
We need to filter the Algolia search so it only shows blog posts on the blog index page. I'm pretty sure this will do the trick (based on [the docs](https://www.algolia.com/doc/api-reference/api-parameters/filters/#examples), but want to double-check with deploy preview.