### PR TITLE
fix: theme flashing

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -65,10 +65,12 @@
     <link rel="preconnect" href="https://www.googletagmanager.com/">
 
     <script>
-            let theme = window.localStorage.getItem("theme");
+        (function() {
+            var theme = window.localStorage.getItem("theme");
             if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 document.documentElement.setAttribute('data-theme', 'dark');
             } else if (theme) document.documentElement.setAttribute('data-theme', theme);
+        })();
     </script>
 
 

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -65,12 +65,10 @@
     <link rel="preconnect" href="https://www.googletagmanager.com/">
 
     <script>
-        (function() {
-            var theme = window.localStorage.getItem("theme");
+            let theme = window.localStorage.getItem("theme");
             if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 document.documentElement.setAttribute('data-theme', 'dark');
             } else if (theme) document.documentElement.setAttribute('data-theme', theme);
-        })();
     </script>
 
 

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -10,8 +10,6 @@
 
 
     let theme = window.localStorage.getItem("theme");
-    document.documentElement.setAttribute('data-theme', theme);
-    if (!theme) document.documentElement.setAttribute('data-theme', 'light');
 
     document.addEventListener('DOMContentLoaded', function() {
         var switcher = document.getElementById('js-theme-switcher');
@@ -20,12 +18,6 @@
         var light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
 
-        // get any previously-chosen themes
-        var theme = window.localStorage.getItem("theme");
-        if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.documentElement.setAttribute('data-theme', 'dark');
-        }
-        else if (theme) document.documentElement.setAttribute('data-theme', theme);
 
         if (theme == "light") {
             enableToggle(light_theme_toggle);


### PR DESCRIPTION
When the site loads and no theme is set in the localstorage the site flashes between dark and light mode (when the system is in dark mode)

### How to reproduce: 
- set system theme as dark mode and clear the site's localstorage
- reload the page the page might flash 

Removed some code that are same as the one we already have inside layout
- https://github.com/eslint/new.eslint.org/blob/824c4bf34390a5781dc69f2ca993a873e37d4e15/src/_includes/layouts/base.html#L67-L74

Before: 

https://user-images.githubusercontent.com/32865581/164293001-dac07d15-1a86-4837-8205-a5257f6e42e7.mov

