### PR TITLE
fix: theme buttons in chinese

### DIFF
--- a/src/assets/scss/components/theme-switcher.scss
+++ b/src/assets/scss/components/theme-switcher.scss
@@ -22,7 +22,6 @@
 }
 
 .theme-switcher__button {
-    flex: 0;
     box-shadow: var(--shadow-xs);
     padding: .625rem .875rem;
     display: inline-flex;


### PR DESCRIPTION
Before: 
- https://github.com/eslint/new.eslint.org/issues/197

After: 
![Screenshot 2022-04-22 at 2 42 40 PM](https://user-images.githubusercontent.com/32865581/164675800-10587945-2275-44fa-92bb-c921e7f79992.png)
No breakage in other languages as well 
![Screenshot 2022-04-22 at 2 44 49 PM](https://user-images.githubusercontent.com/32865581/164676047-2cebfba4-55a7-4c5d-b357-c054b0ec7df3.png)
![Screenshot 2022-04-22 at 2 45 35 PM](https://user-images.githubusercontent.com/32865581/164676164-61f94617-d1a2-4e1b-bc2d-e6c4dc46829f.png)

This `flex: 0` is not needed for that button I guess