### PR TITLE
chore: Update robots.txt and _redirects

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -23,5 +23,5 @@ eleventyExcludeFromCollections: true
 
 {% if site.language.code != "en" %}
 # Translation Blog Redirects
-https://{{ site.hostname }}/blog/*      https://new.eslint.org/blog/:splat 302!
+https://{{ site.hostname }}/blog/*      https://eslint.org/blog/:splat 302!
 {% endif %}

--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -1,3 +1,9 @@
+---
+layout: false
+permalink: _redirects
+eleventyExcludeFromCollections: true
+---
+
 # Netlify Redirect Rules
 # https://www.netlify.com/docs/redirects/
 
@@ -10,11 +16,12 @@
 
 # Internal Redirects
 /docs/*                             https://eslint.org/docs/:splat 302!
+/demo/*                             /play/:splat 302!
 
 # Proxied Endpoints
 /play/*                             https://play-eslint.netlify.app/:splat 200!
 
+{% if site.language.code != "en" %}
 # Translation Blog Redirects
-https://es.eslint.org/blog/*        https://new.eslint.org/blog/:splat 302!
-https://ja.eslint.org/blog/*        https://new.eslint.org/blog/:splat 302!
-https://new.cn.eslint.org/blog/*        https://new.eslint.org/blog/:splat 302!
+https://{{ site.hostname }}/blog/*      https://new.eslint.org/blog/:splat 302!
+{% endif %}

--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -5,4 +5,7 @@ eleventyExcludeFromCollections: true
 ---
 Sitemap: https://{{ site.hostname }}/sitemap.xml
 User-agent: *
+
+{% if "new." in site.hostname %}
 Disallow: /
+{% endif %}


### PR DESCRIPTION
This changes makes both `robots.txt` and `_redirects` site-aware. Specifically:

1. Disallows crawlers for any site that has "new." in the hostname, such as new.eslint.org and new.cn.eslint.org, because these sites are effectively in beta and we don't want Googlebot to crawl those while eslint.org and cn.eslint.org are active. All other translation sites are allowed to be crawled.
2. Automatically includes a redirect from /blog in all translations to the English /blog entrypoint. We aren't translating blog posts, so this will make sure all of the SEO power goes to the active blog posts on eslint.org.
3. Added a redirect from /demo to /play.