### PR TITLE
Fix twitter:card

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -46,7 +46,7 @@
     <meta property="og:url" content="{{ metadata.url }}{{ page.url }}">
     <!-- Twitter -->
     <meta name="twitter:title" content="{{ page_title }}">
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@geteslint">
     <meta name="twitter:description" content="{{ page_desc }}">
     <meta name="twitter:image" content="{{ cover_image }}">


### PR DESCRIPTION
The aspect ratio of `icon-512.png` is 1:1. `summary` supports 1:1. `summary_large_image` supports 2:1. This changes `twitter:card` to more suitable one.

https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary
https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image