### PR TITLE
fix: add tabindex to donate in navbar

### DIFF
--- a/src/_includes/components/navigation.html
+++ b/src/_includes/components/navigation.html
@@ -1,6 +1,6 @@
 <nav class="site-nav" aria-label="Main">
     <div class="flexer">
-        <a href="{{ links.donate }}" class="c-btn c-btn--primary donate-link">{{ site.donate_page.title }}</a>
+        <a href="{{ links.donate }}" class="c-btn c-btn--primary donate-link" tabindex="0">{{ site.donate_page.title }}</a>
         <button class="site-nav-toggle" aria-label="Menu" id="nav-toggle" hidden>
             <svg width="20" height="20" viewBox="20 20 60 60">
                 <path id="ham-top"    d="M30,37 L70,37 Z" stroke="currentColor"></path>


### PR DESCRIPTION
Adds a `tabindex` to navigation bar for accessibility purposes.