### PR TITLE
fix: set default theme

### DIFF
--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -1,31 +1,27 @@
 /* theme toggle buttons */
-(function() {
-    const enableToggle =btn=> {
+(function () {
+    const enableToggle = btn => {
         btn.setAttribute("aria-pressed", "true");
     }
-
-    const disableToggle =btn => {
+    const disableToggle = btn => {
         btn.setAttribute("aria-pressed", "false");
     }
-    const setTheme = theme=>{
+    const setTheme = theme => {
         document.documentElement.setAttribute('data-theme', theme);
         window.localStorage.setItem("theme", theme);
     }
 
     let theme = window.localStorage.getItem("theme");
-    if(!theme || !(theme==="light") || !(theme==="dark")){
+    if (!theme || !(theme === "light") || !(theme === "dark")) {
         let isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         theme = isDark ? "dark" : "light";
     }
 
-    document.addEventListener('DOMContentLoaded', function() {
+    document.addEventListener('DOMContentLoaded', function () {
         const switcher = document.getElementById('js-theme-switcher');
         switcher.removeAttribute('hidden');
-
         const light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
-
-
         if (theme === "light") {
             enableToggle(light_theme_toggle);
             disableToggle(dark_theme_toggle);
@@ -35,21 +31,18 @@
             disableToggle(light_theme_toggle);
             setTheme(theme);
         }
-
-        light_theme_toggle.addEventListener("click", function() {
+        light_theme_toggle.addEventListener("click", function () {
             enableToggle(light_theme_toggle);
             theme = this.getAttribute('data-theme');
             setTheme(theme);
             disableToggle(dark_theme_toggle);
-            
-        }, false);
 
-        dark_theme_toggle.addEventListener("click", function() {
+        }, false);
+        dark_theme_toggle.addEventListener("click", function () {
             enableToggle(dark_theme_toggle);
             theme = this.getAttribute('data-theme');
             setTheme(theme);
             disableToggle(light_theme_toggle);
         }, false);
     }, false);
-
 })();

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -13,6 +13,7 @@
 
     var theme = window.localStorage.getItem("theme");
     if (!theme || (theme !== "light" && theme !== "dark")) {
+        var isChanged = true;
         var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         theme = isDark ? "dark" : "light";
     }
@@ -22,14 +23,16 @@
         switcher.removeAttribute('hidden');
         var light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
-        if (theme === "light") {
-            enableToggle(light_theme_toggle);
-            disableToggle(dark_theme_toggle);
-            setTheme(theme);
-        } else if (theme === "dark") {
-            enableToggle(dark_theme_toggle);
-            disableToggle(light_theme_toggle);
-            setTheme(theme);
+        if (isChanged) {
+            if (theme === "light") {
+                enableToggle(light_theme_toggle);
+                disableToggle(dark_theme_toggle);
+                setTheme(theme);
+            } else if (theme === "dark") {
+                enableToggle(dark_theme_toggle);
+                disableToggle(light_theme_toggle);
+                setTheme(theme);
+            }
         }
         light_theme_toggle.addEventListener("click", function () {
             enableToggle(light_theme_toggle);

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -1,47 +1,53 @@
 /* theme toggle buttons */
 (function() {
-    var enableToggle = function(btn) {
+    const enableToggle =btn=> {
         btn.setAttribute("aria-pressed", "true");
     }
 
-    var disableToggle = function(btn) {
+    const disableToggle =btn => {
         btn.setAttribute("aria-pressed", "false");
     }
-
+    const setTheme = theme=>{
+        document.documentElement.setAttribute('data-theme', theme);
+        window.localStorage.setItem("theme", theme);
+    }
 
     let theme = window.localStorage.getItem("theme");
+    if(!theme || !(theme==="light") || !(theme==="dark")){
+        let isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = isDark ? "dark" : "light";
+    }
 
     document.addEventListener('DOMContentLoaded', function() {
-        var switcher = document.getElementById('js-theme-switcher');
+        const switcher = document.getElementById('js-theme-switcher');
         switcher.removeAttribute('hidden');
 
-        var light_theme_toggle = document.getElementById('light-theme-toggle'),
+        const light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
 
 
-        if (theme == "light") {
+        if (theme === "light") {
             enableToggle(light_theme_toggle);
             disableToggle(dark_theme_toggle);
-        } else if (theme == "dark") {
+            setTheme(theme);
+        } else if (theme === "dark") {
             enableToggle(dark_theme_toggle);
             disableToggle(light_theme_toggle);
+            setTheme(theme);
         }
 
         light_theme_toggle.addEventListener("click", function() {
             enableToggle(light_theme_toggle);
             theme = this.getAttribute('data-theme');
-            document.documentElement.setAttribute('data-theme', theme);
-            window.localStorage.setItem("theme", theme);
-
+            setTheme(theme);
             disableToggle(dark_theme_toggle);
+            
         }, false);
 
         dark_theme_toggle.addEventListener("click", function() {
             enableToggle(dark_theme_toggle);
             theme = this.getAttribute('data-theme');
-            document.documentElement.setAttribute('data-theme', theme);
-            window.localStorage.setItem("theme", theme);
-
+            setTheme(theme);
             disableToggle(light_theme_toggle);
         }, false);
     }, false);

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -1,26 +1,26 @@
 /* theme toggle buttons */
 (function () {
-    const enableToggle = btn => {
+    var enableToggle = function (btn) {
         btn.setAttribute("aria-pressed", "true");
     }
-    const disableToggle = btn => {
+    var disableToggle = function (btn) {
         btn.setAttribute("aria-pressed", "false");
     }
-    const setTheme = theme => {
+    var setTheme = function (theme) {
         document.documentElement.setAttribute('data-theme', theme);
         window.localStorage.setItem("theme", theme);
     }
 
-    let theme = window.localStorage.getItem("theme");
-    if (!theme || !(theme === "light") || !(theme === "dark")) {
-        let isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var theme = window.localStorage.getItem("theme");
+    if (!theme || (theme !== "light" && theme !== "dark")) {
+        var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         theme = isDark ? "dark" : "light";
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        const switcher = document.getElementById('js-theme-switcher');
+        var switcher = document.getElementById('js-theme-switcher');
         switcher.removeAttribute('hidden');
-        const light_theme_toggle = document.getElementById('light-theme-toggle'),
+        var light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
         if (theme === "light") {
             enableToggle(light_theme_toggle);


### PR DESCRIPTION
**Current behavior:** 
Theme not set initially both light & dark theme animated dropdowns are shown. Below I have attached screenshots for your reference.

| In desktop  | In mobile |
| ------------- | ------------- |
| <img width="420" alt="image" src="https://user-images.githubusercontent.com/30730124/167247781-ee51fd61-eda6-4a7e-9cf1-d26a4614bb35.png">  |  <img width="240" height="480" alt="image" src="https://user-images.githubusercontent.com/30730124/167248023-9665e3dd-aefd-4dc2-b15d-414c38e8f206.png">  |  




**Steps to reproduce:**
When we open the website for the first time this bug will be reproduced when the theme is not selected on your device or when then the theme is light.
Device: MacBook Pro 2019 
OS: macOS Big Sur 
Browser: Chrome Version 100.0.4896.60
Ref: https://share.vidyard.com/watch/At5DoYpzWTnJTX6JzqTxxs


**Change:**
Set system prefers-color-scheme as the initial theme.


