### PR TITLE
chore: replace addListener with addEventListener

### DIFF
--- a/src/assets/js/components-index.js
+++ b/src/assets/js/components-index.js
@@ -6,7 +6,7 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 

--- a/src/assets/js/docs-main.js
+++ b/src/assets/js/docs-main.js
@@ -6,7 +6,7 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 1023px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change', WidthChange);
         WidthChange(mq);
     }
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -6,12 +6,13 @@
 
     if (matchMedia) {
         const mq = window.matchMedia("(max-width: 680px)");
-        mq.addListener(WidthChange);
+        mq.addEventListener('change',WidthChange);
         WidthChange(mq);
     }
 
     // media query change
     function WidthChange(mq) {
+        console.log('add listener working as expected');
         if (mq.matches) {
             nav.setAttribute("data-open", "false");
             nav_trigger.removeAttribute("hidden");

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -12,7 +12,6 @@
 
     // media query change
     function WidthChange(mq) {
-        console.log('add listener working as expected');
         if (mq.matches) {
             nav.setAttribute("data-open", "false");
             nav_trigger.removeAttribute("hidden");


### PR DESCRIPTION
 use addEventListener() instead of matchMedia().addListener() since matchMedia().addListener() is deprecated.