### PR TITLE
fix: Redirect to homepage on logo-link click

### DIFF
--- a/src/assets/scss/header.scss
+++ b/src/assets/scss/header.scss
@@ -28,6 +28,7 @@
     grid-column: 1 / -1;
     grid-row: 1;
     padding: .5rem 0;
+    z-index: 2;
 }
 
 .logo svg {


### PR DESCRIPTION
**Description:**
In mobile view logo-link is not working it is not redirecting to the homepage. 

**Why it is not working in mobile view?**
In mobile view, site-navbar takes up the full width the logo-link element goes behind the site-navbar element. So the logo link is not clickable. 
<img width="580" alt="image" src="https://user-images.githubusercontent.com/30730124/167476671-52ff0a60-be7b-4992-8d59-4fb54c180b12.png">

**Steps to reproduce:**
Open the [new.eslint.org/team](https://new.eslint.org/team/) website on mobile and click on the eslint logo (logo-link element) in the navbar. 
Expected behavior: It should redirect to the homepage [new.eslint.org](https://new.eslint.org)
Actual behavior: Eslint logo is not clickable.

Device details:
OS: Android v10
Browser: Chrome 101.0.4951.41
Mobile device-width: <679px

**Fix:**
stacked the logo-link element on the top.
Note: There are multiple ways to fix this issue. Adding a z-index seems to be an easier fix.