### PR TITLE
fix: removes layout shift when opening navbar in mobile

### DIFF
--- a/src/assets/scss/animation.scss
+++ b/src/assets/scss/animation.scss
@@ -15,7 +15,7 @@
       height: 100%;
       transform: scaleX(var(--scale));
       transform-origin: center right;
-      z-index: 999;
+      z-index: 3;
     }
   }
 }

--- a/src/assets/scss/foundations.scss
+++ b/src/assets/scss/foundations.scss
@@ -98,6 +98,7 @@ body {
 }
 
 main {
+    padding-top: 4.5rem;
     flex: 1;
 
     &:focus {

--- a/src/assets/scss/header.scss
+++ b/src/assets/scss/header.scss
@@ -1,4 +1,8 @@
 .site-header {
+    position: absolute;
+    z-index: 4;
+    background: var(--body-background-color);
+    width: 100%;
     padding: .75rem 0;
     border-top: 4px solid var(--link-color);
     border-bottom: 1px solid var(--divider-color);


### PR DESCRIPTION
IDK if this was intentional but thought it would be better if there was no shift when opening nav

Before:

https://user-images.githubusercontent.com/32865581/167675201-4dd8a930-4073-40d2-b533-81cdf381e90f.mov

After:

https://user-images.githubusercontent.com/32865581/167675228-4a8d88fb-930c-45c0-967d-50ec97c42036.mov

