### PR TITLE
fix: highlight selected theme

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -65,12 +65,13 @@
     <link rel="preconnect" href="https://www.googletagmanager.com/">
 
     <script>
-        (function() {
-            var theme = window.localStorage.getItem("theme");
-            if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                document.documentElement.setAttribute('data-theme', 'dark');
-            } else if (theme) document.documentElement.setAttribute('data-theme', theme);
-        })();
+            (function () {
+                var theme = window.localStorage.getItem("theme");
+                if (theme) document.documentElement.setAttribute('data-theme', theme)
+                else if (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                else document.documentElement.setAttribute('data-theme', 'light');
+            })();
     </script>
 
 

--- a/src/assets/js/themes.js
+++ b/src/assets/js/themes.js
@@ -12,26 +12,18 @@
     }
 
     var theme = window.localStorage.getItem("theme");
-    if (!theme || (theme !== "light" && theme !== "dark")) {
-        var isChanged = true;
-        var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        theme = isDark ? "dark" : "light";
-    }
-
     document.addEventListener('DOMContentLoaded', function () {
         var switcher = document.getElementById('js-theme-switcher');
         switcher.removeAttribute('hidden');
         var light_theme_toggle = document.getElementById('light-theme-toggle'),
             dark_theme_toggle = document.getElementById('dark-theme-toggle');
-        if (isChanged) {
+        if (theme) {
             if (theme === "light") {
                 enableToggle(light_theme_toggle);
                 disableToggle(dark_theme_toggle);
-                setTheme(theme);
             } else if (theme === "dark") {
                 enableToggle(dark_theme_toggle);
                 disableToggle(light_theme_toggle);
-                setTheme(theme);
             }
         }
         light_theme_toggle.addEventListener("click", function () {
@@ -39,7 +31,6 @@
             theme = this.getAttribute('data-theme');
             setTheme(theme);
             disableToggle(dark_theme_toggle);
-
         }, false);
         dark_theme_toggle.addEventListener("click", function () {
             enableToggle(dark_theme_toggle);


### PR DESCRIPTION
### Description:
Highlighted selected theme.

### Before:
User selected theme was not highlighted. It is a miss from my end in my previous PR [#208](https://github.com/eslint/new.eslint.org/pull/208) 

### Steps to reproduce:
Select a theme and reload the page. 

### After:
Highlighted the user selected theme.


### Details:
**base.html** 
- Gives first preference to user selected theme. If the theme is not available apply based on system preferences. 

**theme.js** 
-  highlights the selected theme. 
-  Toggles the theme when it is changed and stores it.