### PR TITLE
feat: Use playground in navigation

### DIFF
--- a/src/_data/links.json
+++ b/src/_data/links.json
@@ -6,7 +6,7 @@
 
     "blog": "/blog",
     "docs": "https://eslint.org/docs",
-    "playground": "https://eslint.org/demo",
+    "playground": "/play",
     "getStarted": "https://eslint.org/docs/user-guide/getting-started",
     "sponsors": "/sponsors",
     "branding": "/branding",


### PR DESCRIPTION
Updated the header link for the Playground to go to /play instead of the demo.