### PR TITLE
feat: Enable proxying to docs site

### DIFF
--- a/src/static/redirects.njk
+++ b/src/static/redirects.njk
@@ -15,10 +15,10 @@ eleventyExcludeFromCollections: true
 /chat                               https://discord.gg/8szcydm 302!
 
 # Internal Redirects
-/docs/*                             https://eslint.org/docs/:splat 302!
 /demo/*                             /play/:splat 302!
 
 # Proxied Endpoints
+/docs/*                             https://docs-eslint.netlify.app/:splat 200!
 /play/*                             https://play-eslint.netlify.app/:splat 200!
 
 {% if site.language.code != "en" %}


### PR DESCRIPTION
This enables proxying to the docs site from `/docs`