### PR TITLE
fix: disallow cursor for disabled tag

### DIFF
--- a/src/assets/scss/components/pagination.scss
+++ b/src/assets/scss/components/pagination.scss
@@ -33,10 +33,12 @@ nav.c-pagination {
     &[aria-disabled] {
         color: var(--body-text-color);
         border-color: var(--divider-color);
+        cursor: not-allowed;
 
         &:hover {
             border-color: var(--divider-color);
         }
+
     }
 }
 

--- a/src/assets/scss/components/pagination.scss
+++ b/src/assets/scss/components/pagination.scss
@@ -38,7 +38,6 @@ nav.c-pagination {
         &:hover {
             border-color: var(--divider-color);
         }
-
     }
 }
 

--- a/src/assets/scss/components/slider.scss
+++ b/src/assets/scss/components/slider.scss
@@ -39,6 +39,7 @@
             svg {
                 color: var(--color-neutral-400);
             }
+            cursor: not-allowed;
         }
 
         &:hover {


### PR DESCRIPTION
**Changes:**

Disallow the cursor when the tag is disabled.

**Before:**
<img width="260" alt="image" src="https://user-images.githubusercontent.com/30730124/169693536-5aea0b3c-e2c0-4927-ba20-ec7e3d397be4.png">

**After:**
<img width="260" alt="image" src="https://user-images.githubusercontent.com/30730124/169693459-8ec52b4b-bbcc-4889-b3d0-7359b28d161b.png">
