### PR TITLE
Revert "perf: use system's own flag on non-Windows systems"

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -123,6 +123,9 @@
                 });
             });
         }
+        if (/windows/i.test(navigator.userAgent)) {
+            document.body.classList.add('win')
+        }
     </script>
     <script src="{{ '/assets/js/themes.js' | url }}"></script>
     {%- if (hook == "blog_page") -%}
@@ -136,11 +139,6 @@
 
     {{ content | safe }}
 
-    <script>
-        if (/windows/i.test(navigator.userAgent)) {
-            document.getElementById("language-select").classList.add("win")
-        }
-    </script>
     <script src="{{ '/assets/js/css-vars-ponyfill@2.js' | url }}"></script>
     <script src="{{ '/assets/js/focus-visible.js' | url }}"></script>
     <script src="{{ '/assets/js/main.js' | url }}"></script>

--- a/src/assets/scss/tokens/typography.scss
+++ b/src/assets/scss/tokens/typography.scss
@@ -63,6 +63,7 @@
             Arial,
             sans-serif,
             "Apple Color Emoji",
+            "Twemoji Country Flags",
             "Segoe UI Emoji",
             "Segoe UI Symbol";
     --display-font: "Space Grotesk",
@@ -76,8 +77,4 @@
             "Apple Color Emoji",
             "Segoe UI Emoji",
             "Segoe UI Symbol";
-}
-
-.win {
-    font-family: "Twemoji Country Flags" !important;
 }


### PR DESCRIPTION
Reverts eslint/new.eslint.org#215

Unfortunately, #215 made it so we are getting the incorrect font displayed in the language picker:

![Screenshot 2022-05-30 at 12-05-53 Trouvez et corrigez les erreurs de votre code JavaScript - ESLint - Correcteur JavaScript Extensible](https://user-images.githubusercontent.com/38546/171057080-26e0da08-f868-48f1-b188-35134cf64f40.png)

