### PR TITLE
build: compress build css and remove unwanted parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "images": "imagemin '_site/assets/images' --out-dir='_site/assets/images'",
         "watch:sass": "sass --watch src/assets/scss:src/assets/css",
         "watch:eleventy": "eleventy --serve --port=2022",
-        "build:sass": "sass src/assets/scss:src/assets/css",
+        "build:sass": "sass --no-source-map --style=compressed src/assets/scss:src/assets/css",
         "build:eleventy": "npx @11ty/eleventy",
         "fetch:team": "node tools/fetch-team-data.js",
         "fetch:stats": "node tools/fetch-stats.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
         "start": "npm-run-all --parallel watch:* images",
-        "build": "npm-run-all --parallel build:* images"
+        "build": "npm-run-all build:* images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
         "start": "npm-run-all --parallel watch:* images",
-        "build": "npm-run-all build:* images"
+        "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "fetch:stats": "node tools/fetch-stats.js",
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
-        "start": "npm-run-all build:sass --parallel watch:*  --parallel images",
-        "build": "npm-run-all build:sass --parallel build:*   --parallel images"
+        "start": "npm-run-all --parallel watch:* images",
+        "build": "npm-run-all --parallel build:* images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
         "start": "npm-run-all build:sass --parallel watch:* images",
-        "build": "npm-run-all build:sass --parallel build:eleventy images"
+        "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "fetch:stats": "node tools/fetch-stats.js",
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
-        "start": "npm-run-all --parallel watch:* images",
+        "start": "npm-run-all build:sass --parallel watch:* images",
         "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "fetch:stats": "node tools/fetch-stats.js",
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
-        "start": "npm-run-all build:sass --parallel watch:* images",
+        "start": "npm-run-all build:sass --parallel watch:*",
         "build": "npm-run-all build:sass build:eleventy images"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "fetch:sponsors": "node tools/fetch-sponsors.js",
         "fetch": "npm-run-all --parallel fetch:*",
         "start": "npm-run-all build:sass --parallel watch:* images",
-        "build": "npm-run-all build:sass build:eleventy images"
+        "build": "npm-run-all build:sass --parallel build:eleventy images"
     },
     "devDependencies": {
         "@11ty/eleventy": "^1.0.0",


### PR DESCRIPTION
use `watch:sass` instead of `build:sass` and `npm-run-all` requires only one `--parallel`