### PR TITLE
fix: show navlist when script disabled

### DIFF
--- a/src/_includes/components/navigation.html
+++ b/src/_includes/components/navigation.html
@@ -1,7 +1,7 @@
 <nav class="site-nav" aria-label="Main">
     <div class="flexer">
         <a href="{{ links.donate }}" class="c-btn c-btn--primary donate-link">{{ site.donate_page.title }}</a>
-        <button class="site-nav-toggle" aria-label="Menu" id="nav-toggle" hidden>
+        <button class="site-nav-toggle" aria-label="Menu" id="nav-toggle">
             <svg width="20" height="20" viewBox="20 20 60 60">
                 <path id="ham-top"    d="M30,37 L70,37 Z" stroke="currentColor"></path>
                 <path id="ham-middle" d="M30,50 L70,50 Z" stroke="currentColor"></path>
@@ -9,7 +9,7 @@
             </svg>
         </button>
     </div>
-    <ul id="nav-list" data-open="false">
+    <ul id="nav-list">
         {% for item in site.navigation %}
         <li>
             {% set itemLink = links[item.link] %}

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -63,6 +63,9 @@
         .no-js #nav-toggle {
             display: none !important;
         }
+        .no-js #copyBtn{
+            display: none !important;
+        }
         @media all and (min-width: 680px) {
             .enhanced #nav-toggle{
                 display: none;
@@ -71,6 +74,9 @@
         @media all and (max-width: 679px) {
             .no-js #nav-list {
                 display: block !important;
+            }
+            .enhanced #nav-list{
+                display: none;
             }
         }
 

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -52,12 +52,29 @@
     <meta name="twitter:image" content="{{ cover_image }}">
     <meta name="twitter:creator" content="@geteslint">
 
-
-    <script type="module">
+    <script>
         // This is a capable browser, let's improve the UI further!
         document.documentElement.classList.add("enhanced");
         document.documentElement.classList.remove('no-js');
     </script>
+ 
+    <style>
+
+        .no-js #nav-toggle {
+            display: none !important;
+        }
+        @media all and (min-width: 680px) {
+            .enhanced #nav-toggle{
+                display: none;
+            }
+        }
+        @media all and (max-width: 679px) {
+            .no-js #nav-list {
+                display: block !important;
+            }
+        }
+
+    </style>
 
     <link rel="preload" href="{{ '/assets/fonts/SpaceGrotesk-Medium-subset.woff2' | url }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ '/assets/fonts/Inter-Regular-subset.woff2' | url }}" as="font" type="font/woff2" crossorigin>

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -57,30 +57,6 @@
         document.documentElement.classList.add("enhanced");
         document.documentElement.classList.remove('no-js');
     </script>
- 
-    <style>
-
-        .no-js #nav-toggle {
-            display: none !important;
-        }
-        .no-js #copyBtn{
-            display: none !important;
-        }
-        @media all and (min-width: 680px) {
-            .enhanced #nav-toggle{
-                display: none;
-            }
-        }
-        @media all and (max-width: 679px) {
-            .no-js #nav-list {
-                display: block !important;
-            }
-            .enhanced #nav-list{
-                display: none;
-            }
-        }
-
-    </style>
 
     <link rel="preload" href="{{ '/assets/fonts/SpaceGrotesk-Medium-subset.woff2' | url }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ '/assets/fonts/Inter-Regular-subset.woff2' | url }}" as="font" type="font/woff2" crossorigin>

--- a/src/assets/scss/components/index.scss
+++ b/src/assets/scss/components/index.scss
@@ -108,3 +108,20 @@
         }
     }
 }
+
+.no-js button {
+    display: none !important;
+}
+@media all and (min-width: 680px) {
+    .enhanced #nav-toggle {
+        display: none;
+    }
+}
+@media all and (max-width: 679px) {
+    .no-js #nav-list {
+        display: block !important;
+    }
+    .enhanced #nav-list {
+        display: none;
+    }
+}

--- a/src/assets/scss/components/navigation.scss
+++ b/src/assets/scss/components/navigation.scss
@@ -129,6 +129,6 @@
 
 @media (max-width: 679px) {
     #nav-list[data-open="true"] {
-        display: block;
+        display: block !important;
     }
 }

--- a/src/assets/scss/components/navigation.scss
+++ b/src/assets/scss/components/navigation.scss
@@ -5,7 +5,6 @@
     grid-column: 1 / -1;
     grid-row: 1;
 
-
     ul {
         list-style: none;
         font-size: var(--step-1);
@@ -29,7 +28,6 @@
                 display: flex;
             }
         }
-
     }
 
     .flexer {
@@ -41,7 +39,7 @@
     a:not(.c-btn) {
         text-decoration: none;
         color: inherit;
-        transition: color .2s linear;
+        transition: color 0.2s linear;
         display: block;
 
         &:hover {
@@ -61,12 +59,11 @@
     cursor: pointer;
     display: inline-flex;
     align-items: center;
-    margin-left: .5rem;
+    margin-left: 0.5rem;
     margin-right: -10px;
 
-    margin-inline-start: .5rem;
+    margin-inline-start: 0.5rem;
     margin-inline-end: -10px;
-
 
     svg {
         width: 40px;
@@ -81,7 +78,7 @@
     #ham-top,
     #ham-middle,
     #ham-bottom {
-        transition: all .2s linear;
+        transition: all 0.2s linear;
     }
 
     #ham-top {
@@ -98,7 +95,6 @@
         }
 
         #ham-top {
-
             transform: rotate(41deg);
         }
 
@@ -107,8 +103,6 @@
         }
     }
 }
-
-
 
 @media all and (min-width: 680px) {
     .site-nav {
@@ -131,5 +125,10 @@
             order: 1;
         }
     }
+}
 
+@media (max-width: 679px) {
+    #nav-list[data-open="true"] {
+        display: block;
+    }
 }

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -29,7 +29,7 @@ eleventyExcludeFromCollections: true
                 <div class="eslint-install-code-wrapper">
                     <div class="eslint-install-code" role="region" aria-labelledby="eslint-installation">
                         <span hidden id="eslint-installation">{{ site.homepage.install.title }}</span>
-                        <button class="eslint-install-code__btn" id="copyBtn" aria-labelledby="copy-button-label" hidden>
+                        <button class="eslint-install-code__btn" id="copyBtn" aria-labelledby="copy-button-label">
                             <span hidden id="copy-button-label">{{ site.homepage.install.title }}</span>
                             <svg width="20" height="20" viewBox="0 0 20 20" class="c-icon" role="img" aria-label="copy" fill="none" focusable="false">
                                 <path d="M4.16667 12.5H3.33333C2.89131 12.5 2.46738 12.3244 2.15482 12.0118C1.84226 11.6993 1.66667 11.2754 1.66667 10.8333V3.33332C1.66667 2.8913 1.84226 2.46737 2.15482 2.15481C2.46738 1.84225 2.89131 1.66666 3.33333 1.66666H10.8333C11.2754 1.66666 11.6993 1.84225 12.0118 2.15481C12.3244 2.46737 12.5 2.8913 12.5 3.33332V4.16666M9.16667 7.49999H16.6667C17.5871 7.49999 18.3333 8.24618 18.3333 9.16666V16.6667C18.3333 17.5871 17.5871 18.3333 16.6667 18.3333H9.16667C8.24619 18.3333 7.5 17.5871 7.5 16.6667V9.16666C7.5 8.24618 8.24619 7.49999 9.16667 7.49999Z" stroke="currentColor" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round" />


### PR DESCRIPTION
**Description:**
Show navbar elements when the script is disabled and reduce cls

Before:
Navbar list elements were not shown when js was disabled.
https://github.com/eslint/new.eslint.org/pull/167 reduces layout shift in mobile view but hiding navlist by default causes issue when script is disabled.  
<img width="800" alt="image" src="https://user-images.githubusercontent.com/30730124/171482066-513b979e-0c8a-416b-8cc3-2733172fecc8.png">

After:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/30730124/171483670-223e3f2f-9c46-4cca-8627-1bcbbb5e2148.png">



