### PR TITLE
fix: overlapping slider nav

### DIFF
--- a/src/assets/scss/components/slider.scss
+++ b/src/assets/scss/components/slider.scss
@@ -11,11 +11,7 @@
         margin-block-start: -2rem;
         position: relative;
         z-index: 2;
-
-        .homepage & {
-            margin-top: -4rem;
-            margin-block-start: -4rem;
-        }
+        
     }
 
     .c-slider__paddleNav__prev,


### PR DESCRIPTION
The slider below the testimonial is getting overlapped with the content if the content has more lines in the desktop view. This can be currently seen in French and Spanish sites. 

Before :
<img width="560" alt="image" src ="https://user-images.githubusercontent.com/42372051/172215649-a1b49f26-4fe8-402c-b01e-93d04e14ce2b.png">

After :
<img width="560" alt="image" src="https://user-images.githubusercontent.com/42372051/172216903-40373177-a1c7-4a38-a8da-3c7b35633aa1.png">
