### PR TITLE
feat: add sitemap index file

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -307,6 +307,15 @@ module.exports = eleventyConfig => {
     eleventyConfig.addShortcode("image", imageShortcode)
     // END, eleventy-img
 
+    /*
+     * Do not generate sitemap and sitemap index files for translation sites because we're
+     * always deploying all pages, and the sitemap would include them, but only a few pages
+     * can actually be accessed on translation sites while most URLs (e.g., blog posts)
+     * are redirecting to the English site.
+     */
+    if (siteName !== "en") {
+        eleventyConfig.ignores.add("src/static/sitemap*");
+    }
 
     return {
         passthroughFileCopy: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -307,16 +307,6 @@ module.exports = eleventyConfig => {
     eleventyConfig.addShortcode("image", imageShortcode)
     // END, eleventy-img
 
-    /*
-     * Do not generate sitemap and sitemap index files for translation sites because we're
-     * always deploying all pages, and the sitemap would include them, but only a few pages
-     * can actually be accessed on translation sites while most URLs (e.g., blog posts)
-     * are redirecting to the English site.
-     */
-    if (siteName !== "en") {
-        eleventyConfig.ignores.add("src/static/sitemap*");
-    }
-
     return {
         passthroughFileCopy: true,
 

--- a/src/content/pages/branding.html
+++ b/src/content/pages/branding.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /branding/
+multilingual: true
 eleventyExcludeFromCollections: true
 hook: "branding_page"
 ---

--- a/src/content/pages/donate.html
+++ b/src/content/pages/donate.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /donate/
+multilingual: true
 hook: "donate_page"
 ---
 

--- a/src/content/pages/index.html
+++ b/src/content/pages/index.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /
+multilingual: true
 desc: ESLint statically analyzes your code to quickly find problems. It is built into most text editors and you can run ESLint as part of your continuous integration pipeline.
 cover: /assets/images/site-cover.jpg
 hook: "homepage"

--- a/src/content/pages/languages.html
+++ b/src/content/pages/languages.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /languages/
+multilingual: true
 hook: "languages_page"
 ---
 

--- a/src/content/pages/sponsors.html
+++ b/src/content/pages/sponsors.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /sponsors/
+multilingual: true
 eleventyExcludeFromCollections: true
 hook: "sponsors_page"
 ---

--- a/src/content/pages/team.html
+++ b/src/content/pages/team.html
@@ -1,6 +1,7 @@
 ---
 layout: main.html
 permalink: /team/
+multilingual: true
 hook: "team_page"
 ---
 

--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -3,8 +3,7 @@ layout: false
 permalink: robots.txt
 eleventyExcludeFromCollections: true
 ---
-{% if site.language.code == "en" %}
 Sitemap: https://{{ site.hostname }}/sitemap-index.xml
-{% endif %}
+
 User-agent: *
 {% if "new." in site.hostname %}Disallow: /{% endif %}

--- a/src/static/robots.njk
+++ b/src/static/robots.njk
@@ -3,9 +3,8 @@ layout: false
 permalink: robots.txt
 eleventyExcludeFromCollections: true
 ---
-Sitemap: https://{{ site.hostname }}/sitemap.xml
-User-agent: *
-
-{% if "new." in site.hostname %}
-Disallow: /
+{% if site.language.code == "en" %}
+Sitemap: https://{{ site.hostname }}/sitemap-index.xml
 {% endif %}
+User-agent: *
+{% if "new." in site.hostname %}Disallow: /{% endif %}

--- a/src/static/sitemap-index.njk
+++ b/src/static/sitemap-index.njk
@@ -7,7 +7,9 @@ eleventyExcludeFromCollections: true
     <sitemap>
         <loc>{{ ["https://", site.hostname, "/sitemap.xml"] | join }}</loc>
     </sitemap>
+    {% if site.language.code == "en" %}
     <sitemap>
         <loc>{{ ["https://", site.hostname, "/docs/latest/sitemap.xml"] | join }}</loc>
-    </sitemap>    
+    </sitemap>
+    {% endif %}
 </sitemapindex>

--- a/src/static/sitemap-index.njk
+++ b/src/static/sitemap-index.njk
@@ -1,0 +1,13 @@
+---
+permalink: /sitemap-index.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>{{ ["https://", site.hostname, "/sitemap.xml"] | join }}</loc>
+    </sitemap>
+    <sitemap>
+        <loc>{{ ["https://", site.hostname, "/docs/latest/sitemap.xml"] | join }}</loc>
+    </sitemap>    
+</sitemapindex>

--- a/src/static/sitemap.njk
+++ b/src/static/sitemap.njk
@@ -6,9 +6,9 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
         <url>
-            <loc>{{ site.url }}{{ page.url | url }}</loc>
+            <loc>{{ ["https://", site.hostname, page.url | url] | join }}</loc>
             <lastmod>{{ page.date.toISOString() }}</lastmod>
-            <changefreq>{{ page.data.changeFreq or &quot;monthly&quot; }}</changefreq>
+            <changefreq>{{ page.data.changeFreq if page.data.changeFreq else "monthly" }}</changefreq>
         </url>
     {% endfor %}
 </urlset>

--- a/src/static/sitemap.njk
+++ b/src/static/sitemap.njk
@@ -5,10 +5,12 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     {% for page in collections.all %}
-        <url>
-            <loc>{{ ["https://", site.hostname, page.url | url] | join }}</loc>
-            <lastmod>{{ page.date.toISOString() }}</lastmod>
-            <changefreq>{{ page.data.changeFreq if page.data.changeFreq else "monthly" }}</changefreq>
-        </url>
+    {%- if site.language.code == "en" or page.data.multilingual == true %}
+    <url>
+        <loc>{{ ["https://", site.hostname, page.url | url] | join }}</loc>
+        <lastmod>{{ page.date.toISOString() }}</lastmod>
+        <changefreq>{{ page.data.changeFreq if page.data.changeFreq else "monthly" }}</changefreq>
+    </url>
+    {% endif -%}
     {% endfor %}
 </urlset>


### PR DESCRIPTION
Fixes #232

This PR:

* Fixes URLs in `<loc>` tags of the sitemap to be absolute as required by https://sitemaps.org/protocol.html.
* Fixes code that generates `<changefreq>` in the sitemap. It was always empty (`<changefreq></changefreq>`), which is technically invalid against https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
* Adds `sitemap-index.xml` file in the root. It will contain references to `https://eslint.org/sitemap.xml` and `https://eslint.org/docs/latest/sitemap.xml`. On translation sites, it will contain only one reference, e.g, `https://es.eslint.org/sitemap.xml`.
* Updates `robots.txt` to point to `sitemap-index.xml` instead of `sitemap.xml`.
* Also removes blank line between `User-agent` and `Disallow`, as blank lines are delimiters.
* ~Disables generating sitemaps on translation sites (see the comment in `.eleventy.js`).~
* Adds `multilingual: true` to pages that appear on translation sites and filters the sitemaps for translation sites by this property.