### PR TITLE
feat: Update blog posts and authors file

### DIFF
--- a/src/_data/all_authors.json
+++ b/src/_data/all_authors.json
@@ -1,4 +1,15 @@
 {
+    "eslintbot": {
+        "username": "eslintbot",
+        "name": "ESLint Bot",
+        "title": "Friendly Automation Bot",
+        "website": "https://eslint.org",
+        "avatar_url": "https://avatars.githubusercontent.com/u/13383618?v=4",
+        "bio": "I help the ESLint team do things automatically.",
+        "twitter_username": "geteslint",
+        "github_username": "eslintbot",
+        "location": "Mountain View, CA"
+    },
     "nzakas": {
         "username": "nzakas",
         "name": "Nicholas C. Zakas",

--- a/src/content/blog/2022-02-11-eslint-v8.9.0-released.md
+++ b/src/content/blog/2022-02-11-eslint-v8.9.0-released.md
@@ -1,0 +1,67 @@
+---
+layout: post
+title: ESLint v8.9.0 released
+teaser: "We just pushed ESLint v8.9.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+## Highlights
+
+* New `es2022` [environment](/docs/user-guide/configuring/language-options#specifying-environments) has been added. When enabled, it adds all ECMAScript 2022 globals (which are currently the same as ECMAScript 2021 globals) and automatically sets the `ecmaVersion` parser option to `13`. Previously, we used to add new ES environments only if they contain new globals compared to previous years. New `es2016`, `es2018`, and `es2019` environments have also been added to fill in the gaps between years.
+* `eslint-scope` has been updated to ignore `"use strict"` directives in ES3 code.
+* `eslint-visitor-keys` package now contains built-in TypeScript declarations.
+
+
+
+
+
+
+## Features
+
+
+* [`68f64a9`](https://github.com/eslint/eslint/commit/68f64a9218341e5e9d83270c72587e1b413846de) feat: update eslint-scope to ignore `"use strict"` directives in ES3 ([#15595](https://github.com/eslint/eslint/issues/15595)) (Milos Djermanovic)
+* [`db57639`](https://github.com/eslint/eslint/commit/db576396d20f5e31af1a90f8e5d88e08284a1672) feat: add `es2016`, `es2018`, `es2019`, and `es2022` environments ([#15587](https://github.com/eslint/eslint/issues/15587)) (Milos Djermanovic)
+* [`2dc38aa`](https://github.com/eslint/eslint/commit/2dc38aa653f1d5137a9abf82024c67a11620bb7c) feat: fix bug with arrow function return types in [function-paren-newline](/docs/rules/function-paren-newline) ([#15541](https://github.com/eslint/eslint/issues/15541)) (Milos Djermanovic)
+* [`6f940c3`](https://github.com/eslint/eslint/commit/6f940c3ce715327f282c197d0f71b91848e5d83d) feat: Implement FlatRuleTester ([#15519](https://github.com/eslint/eslint/issues/15519)) (Nicholas C. Zakas)
+
+
+
+
+
+
+
+
+## Documentation
+
+
+* [`570a036`](https://github.com/eslint/eslint/commit/570a03699c5abfbcde39bb00fba39329695771e5) docs: add [`one-var`](/docs/rules/one-var) example with `for-loop` initializer ([#15596](https://github.com/eslint/eslint/issues/15596)) (Milos Djermanovic)
+* [`417191d`](https://github.com/eslint/eslint/commit/417191dff0dbfa353675c409e25f27f578ee1559) docs: Remove the $ prefix in terminal commands ([#15565](https://github.com/eslint/eslint/issues/15565)) (Andreas Lewis)
+* [`389ff34`](https://github.com/eslint/eslint/commit/389ff34e26cb8ebad49e5ace0280a1f859f8d7ca) docs: add missing `Variable#scope` property in the scope manager docs ([#15571](https://github.com/eslint/eslint/issues/15571)) (Milos Djermanovic)
+* [`f63795d`](https://github.com/eslint/eslint/commit/f63795dc710f6394d884932034a3e0cbe48f4ad2) docs: [no-eval](/docs/rules/no-eval) replace dead link with working one ([#15568](https://github.com/eslint/eslint/issues/15568)) (rasenplanscher)
+* [`0383591`](https://github.com/eslint/eslint/commit/0383591a6cd7083455af9e34fa9333da7fed46bf) docs: Remove old Markdown issue template ([#15556](https://github.com/eslint/eslint/issues/15556)) (Brandon Mills)
+* [`a8dd5a2`](https://github.com/eslint/eslint/commit/a8dd5a286bcb68595b85cd29490e081251a2c3c7) docs: add 'when not to use it' section in [no-duplicate-case](/docs/rules/no-duplicate-case) docs ([#15563](https://github.com/eslint/eslint/issues/15563)) (Milos Djermanovic)
+* [`1ad439e`](https://github.com/eslint/eslint/commit/1ad439ed1d6c4ee50183c8f5d146a771e6c1be4c) docs: add missed verb in docs ([#15550](https://github.com/eslint/eslint/issues/15550)) (Jeff Mosawy)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`586d45c`](https://github.com/eslint/eslint/commit/586d45c54b8468fb23376b7b2aedf984cf701cc2) chore: Upgrade to espree@9.3.1 ([#15600](https://github.com/eslint/eslint/issues/15600)) (Milos Djermanovic)
+* [`623e1e2`](https://github.com/eslint/eslint/commit/623e1e28643381025b393a379493d9baea9b4869) chore: Upgrade to eslint-visitor-keys@3.3.0 ([#15599](https://github.com/eslint/eslint/issues/15599)) (Milos Djermanovic)
+* [`355b23d`](https://github.com/eslint/eslint/commit/355b23d0c4e050be4e53292f552a47c10ec6e00e) chore: fix outdated link to Code of Conduct in PR template ([#15578](https://github.com/eslint/eslint/issues/15578)) (Rich Trott)
+* [`b10fef2`](https://github.com/eslint/eslint/commit/b10fef25c99134d514fec4ddde19302661db5974) ci: use Node 16 for browser test ([#15569](https://github.com/eslint/eslint/issues/15569)) (Milos Djermanovic)
+* [`92f89fb`](https://github.com/eslint/eslint/commit/92f89fb0647fef10468fd70d6782a845d75330e3) chore: suggest demo link in bug report template ([#15557](https://github.com/eslint/eslint/issues/15557)) (Brandon Mills)
+
+

--- a/src/content/blog/2022-02-23-paying-contributors-sponsoring-projects.md
+++ b/src/content/blog/2022-02-23-paying-contributors-sponsoring-projects.md
@@ -1,0 +1,102 @@
+---
+layout: post
+title: "Paying contributors, sponsoring projects, and more: ESLint's 2022 spending plan"
+teaser: "When ESLint first started accepting donations, we weren't quite sure how to fairly distribute the proceeds. Now, three years into accepting donations, we've settled on a plan for how to use our funds for the betterment of the ESLint project and ecosystem."
+tags:
+  - Sponsorships
+  - Donations
+  - Contributors
+  - Sustainability
+authors:
+  - nzakas
+categories:
+  - Financials
+---
+
+In our [last update on paying contributors](https://eslint.org/blog/2020/10/year-paying-contributors-review), we noted some of the successes and challenges we had as a team. At that time, we were still trying to figure out ESLint's model for sustainability. Having money to spend is one thing but knowing how to best use that money is another. Because we didn't have enough money to pay anyone full time, we tried one maintainer at part time, and that didn't work. After that experiment, we decided to regroup and reevaluate, ultimately deciding to use a per-hour payment system for team members.
+
+Once we settled into the per-hour system, that also gave us information on how many hours each month people were spending on the project. That, in turn, showed us how much money we actually needed each month to continue maintaining ESLint. As a result of that information, we have arrived at a system that we are very pleased with.
+
+## The guiding principle
+
+Before explaining how ESLint is using the money it collects now, it helps to take a step back to understand the guiding principles upon which this approach is based. Each project has different goals for why they are raising money and how it should be spent. For many projects, the goal is to allow the maintainer(s) to work full time on the project. That is a worthy goal provided that the maintainers actually want to work full time on the project. This is a narrow approach to distributing funds in that most or all of the money goes to one or a few people. 
+
+On ESLint, we discovered that we didn't have any team members interested in working on the project full time. So we thought: what if we went in the complete opposite direction? Given that we know people will only work part time, and probably just in their spare time, how could we distribute the funds as widely as possible for the maximum positive impact?
+
+When we asked ourselves this question, we realized that we were circling around a common theme: anything that benefits the ESLint ecosystem is worth supporting financially. The first and most obvious thing that benefits the ecosystem is having people maintaining ESLint, so we clearly need to make sure people are paid fairly for spending their time working on the project. But what else benefits the ecosystem? Well, ESLint is built on top of a bunch of dependencies, and we'd like to support those projects, so what if we donated some of our funds to those projects? There's also a wide range of plugins, parsers, and extensions that help fuel use of ESLint, so what if we started sponsoring some of these projects as well? And we also get a bunch of contributions from outside contributors...what if we paid them?
+
+So by aligning around the idea that anything that benefits the ESLint ecosystem is worth funding, we were able to find ways to spread the money we collected more widely, and we're excited to share the results.
+
+## How we are spending our money now
+
+In general, we regularly spend money on the following things.
+
+### Paying team members per hour
+
+Each month, all ESLint team members can submit an invoice for the number of hours they worked on the project. Anything they do on the project counts, whether that is writing code, writing documentation, triaging issues, participating in our Discord server, attending meetings on behalf of ESLint, contributing to our upstream dependencies, and so on. All contributions to an open source project are valuable, and we feel like compensating team members for any time they spend on the project is the right thing to do.
+
+Right now, the per-hour rate for Technical Steering Committee (TSC) members and Reviewers is $80/hour; the per-hour rate for Committers is $50/hour.
+
+### The contributor pool
+
+One of the things we struggled with was how to fairly pay outside contributors for working on ESLint. We didn't think a standard per-hour rate made much sense because 1) people might contribute without knowing to track their hours ahead of time and 2) trusting people you don't know to accurately report their hours spend is a system that is too easy to exploit. Still, we felt like it wasn't fair for us to pay for team member contributions but not for outside contributions, and so we created the contributor pool.
+
+Each month, we set aside $1,000 specifically to give to outside contributors for any contributions to ESLint. The TSC reviews outside contributions at the end of each month and awards at least $100 to every outside contributor who has made a non-trivial contribution to ESLint. Once again, these contributions are not limited to coding, but can be anything that positively impacts the project. The contributors don't need to apply ahead of time or ask for permission; if you make a significant contribution, you'll get an email from the TSC letting you know how to collect your payment.
+
+In 2021, we awarded over $6,000 to outside contributors, and we look forward to awarding more in 2022. The bottom line here: if you make any non-trivial contribution to ESLint, you will get paid for it.
+
+### Supporting our dependencies
+
+As we [announced in 2020](https://eslint.org/blog/2020/09/supporting-eslint-dependencies), we actively seek out and donate to our dependencies. In general, any project we directly depend on that has an Open Collective account will be considered to receive a donation from ESLint. We are currently supporting five of our dependencies with monthly donations of $150:
+
+* [Ajv](https://npmjs.com/package/ajv) is a JSON schema validator that ESLint uses to validate configuration.
+* [Eleventy](https://www.11ty.dev/) is a Node.js-based static site generator that we use to create [eslint.org](http://eslint.org).
+* [Sindre Sorhus](https://sindresorhus.com/) is a prolific open source developer, and ESLint uses several of his modules, including [`chalk`](https://npmjs.com/package/chalk), [`globals`](https://npmjs.com/package/globals), [`import-fresh`](https://npmjs.com/package/import-fresh), [`strip-ansi`](https://npmjs.com/package/strip-ansi), and [`strip-json-comments`](https://npmjs.com/package/strip-json-comments).
+* [debug](https://npmjs.com/package/debug) is a small tool ESLint uses to output debugging messages when you use the `--debug` flag. 
+* [lint-staged](https://npmjs.com/package/lint-staged) is a simple precommit hook manager that makes it easy to setup linting in your development process.
+
+We think it's important for open source projects that receive a lot of donations to take care of their dependencies. After all, if your project couldn't exist without those dependencies, then they deserve your support.
+
+You can always check to see which projects ESLint is supporting on our [Open Collective page](https://opencollective.com/eslint#category-CONTRIBUTIONS).
+
+### Supporting the community
+
+Once we started supporting our upstream dependencies, we thought, what about the downstream dependencies? There are a lot of projects related to ESLint that enrich the ESLint ecosystem, whether that be a different set of rules, a custom parser, or anything that makes ESLint better to use. We are currently donating $150 per month to these projects:
+
+* [typescript-eslint](https://github.com/typescript-eslint) is the plugin that makes ESLint work with TypeScript.
+* [eslint-plugin-import](https://npmjs.com/package/eslint-plugin-import) is a plugin to help you manage your module imports.
+* [eslint-plugin-jsx-a11y](https://npmjs.com/package/eslint-plugin-jsx-a11y) is a plugin to help you ensure your JSX code is accessible.
+
+Going forward, we are looking to continue supporting community projects like these. The strength of ESLint is in the ecosystem built by you, and we want to support as much of that ecosystem as possible.
+
+### Big projects
+
+The last way we decided to spend money is on what we playfully called "big projects." These are projects that take a lot of time and effort, and that the team doesn't have the time, interest, or expertise to accomplish on our own. Every project has a backlog of tasks that seem too big to ever accomplish, and we realized that we could start making our way through that list by hiring professionals to do the work.
+
+The first of our big projects is an ambitious project to redesign the ESLint website. We had wanted to redesign our website for several years, and tried at least three separate times to do it in the spirit of open source, with volunteers and designing by consensus. Each of those times the efforts failed, and so we decided it was time to hire some folks to help us out.
+
+The entire scope of the project is fairly large and includes:
+
+1. A brand design including a logo refresh
+1. A new website design that explains more about what ESLint is and how people use it
+1. Separating the documentation into its own website that is easier to navigate
+1. Separating the demo into its own single-page application to make it easier to maintain and deploy
+1. Rewriting and updating our documentation (from scratch)
+1. Translating our documentation into different languages
+
+So far, we have finished step 1 and are getting close to finishing step 2. To do this, we hired:
+
+* [JellyPepper](https://jellypepper.com/) for the brand refresh and visual design of the website.
+* [Gavin Barnett](https://gavinbarnett.com/) to design our new blog images.
+* [Sara Soueidan](https://www.sarasoueidan.com/) to implement the new website, documentation site, and demo skeleton.
+* [Cassie Evans](https://www.cassie.codes/) to implement a custom homepage animation.
+
+The total cost of this effort has come to about $46,000 and we are thrilled with how everything has gone. This is a perfect example of where hiring professionals to do the work allowed us to move faster and (soon!) improve the website experience for all ESLint users.
+
+## Wrapping up
+
+It took us a while to figure out the right way to use our sponsorship money, but now that we have, we think we've found the best way to sustain ESLint for the future. Making sure that everyone gets paid for non-trivial contributions was a goal we had from the start and we are happy that we finally figured out a way to do that.
+
+Additionally, moving to a model where we share some of our funds with both our dependencies and other ecosystem projects feels more in the spirit of open source. We are an interconnected ecosystem where projects mix and reuse other projects to create even more interesting projects. Just as we would consider contributing code to projects that help us, we also need to consider donating money to those projects. The ESLint team feels grateful for the funding we have received and equally grateful to our dependencies without which ESLint couldn't exist. We hope that this model will spread to other open source projects as well.
+
+And last, we intend to continue hiring professionals to work on big projects. There are a lot of different aspects to running an open source project, and expecting volunteers to handle all of those aspects in unrealistic. We've had a great experience on the website project (which should be completed in the next few months) and we'll be looking for other ways to create more value for the ESLint community going forward.

--- a/src/content/blog/2022-02-25-eslint-v8.10.0-released.md
+++ b/src/content/blog/2022-02-25-eslint-v8.10.0-released.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title: ESLint v8.10.0 released
+teaser: "We just pushed ESLint v8.10.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+
+## Highlights
+
+* The [no-shadow](/docs/rules/no-shadow) rule has a new `ignoreOnInitialization` option.
+* The [no-confusing-arrow](/docs/rules/no-confusing-arrow) rule has a new `onlyOneSimpleParam` option.
+
+
+
+
+
+## Features
+
+
+* [`6e2c325`](https://github.com/eslint/eslint/commit/6e2c325324479df1b3f868cf00a529b67d2c3d82) feat: Add `ignoreOnInitialization` option to [no-shadow](/docs/rules/no-shadow) rule ([#14963](https://github.com/eslint/eslint/issues/14963)) (Soufiane Boutahlil)
+* [`115cae5`](https://github.com/eslint/eslint/commit/115cae54125b9ef509af90620f51d4a692b51ab7) feat: `--debug` prints time it takes to parse a file ([#15609](https://github.com/eslint/eslint/issues/15609)) (Bartek Iwańczuk)
+* [`345e70d`](https://github.com/eslint/eslint/commit/345e70d9d6490fb12b18953f56f3cea28fd61d83) feat: Add `onlyOneSimpleParam` option to [no-confusing-arrow](/docs/rules/no-confusing-arrow) rule ([#15566](https://github.com/eslint/eslint/issues/15566)) (Gautam Arora)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`cdc5802`](https://github.com/eslint/eslint/commit/cdc58025d9a8b522f516c3665d225b69a76c4ee1) fix: Avoid `__dirname` for built-in configs ([#15616](https://github.com/eslint/eslint/issues/15616)) (DoZerg)
+* [`ee7c5d1`](https://github.com/eslint/eslint/commit/ee7c5d14a2cb5ce352d1851cec858b942572d2cc) fix: false positive in [`camelcase`](/docs/rules/camelcase) with combined properties ([#15581](https://github.com/eslint/eslint/issues/15581)) (Nitin Kumar)
+
+
+
+
+## Documentation
+
+
+* [`1005bd5`](https://github.com/eslint/eslint/commit/1005bd525a08208fee124149a6ad4cf9da20d7d5) docs: update CLA information ([#15630](https://github.com/eslint/eslint/issues/15630)) (Nitin Kumar)
+* [`5d65c3b`](https://github.com/eslint/eslint/commit/5d65c3bc1e514ed07406c502437a1642913b27ed) docs: Fix typo in [`no-irregular-whitespace`](/docs/rules/no-irregular-whitespace) ([#15634](https://github.com/eslint/eslint/issues/15634)) (Ryota Sekiya)
+* [`b93af98`](https://github.com/eslint/eslint/commit/b93af98b3c417225a027cabc964c38e779adb945) docs: add links between rules about whitespace around block curly braces ([#15625](https://github.com/eslint/eslint/issues/15625)) (Milos Djermanovic)
+* [`ebc0460`](https://github.com/eslint/eslint/commit/ebc0460c411ea608ba5bab05829a1fd122fe21e8) docs: update babel links ([#15624](https://github.com/eslint/eslint/issues/15624)) (Milos Djermanovic)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`7cec74e`](https://github.com/eslint/eslint/commit/7cec74e842b6e51da1b00a9e9b2c9da97dd17362) chore: upgrade @eslint/eslintrc@1.2.0 ([#15648](https://github.com/eslint/eslint/issues/15648)) (Milos Djermanovic)
+* [`11c8580`](https://github.com/eslint/eslint/commit/11c8580de0dcedd5577cffe2b23d23a322cc97df) chore: read `ESLINT_MOCHA_TIMEOUT` env var in Makefile.js ([#15626](https://github.com/eslint/eslint/issues/15626)) (Piggy)
+* [`bfaa548`](https://github.com/eslint/eslint/commit/bfaa5488bbc794c0d160fb55bd277a2c618953b2) test: add integration tests with built-in configs ([#15612](https://github.com/eslint/eslint/issues/15612)) (Milos Djermanovic)
+* [`39a2fb3`](https://github.com/eslint/eslint/commit/39a2fb3f448a7096bfb2fc172fef6cc3f6a7ed3b) perf: fix lazy loading of core rules ([#15606](https://github.com/eslint/eslint/issues/15606)) (Milos Djermanovic)
+* [`3fc9196`](https://github.com/eslint/eslint/commit/3fc919626ef6a00e35bb6b559b60a1e89cf6ca1a) chore: include `tests/conf` in test runs ([#15610](https://github.com/eslint/eslint/issues/15610)) (Milos Djermanovic)
+
+

--- a/src/content/blog/2022-03-11-eslint-v8.11.0-released.md
+++ b/src/content/blog/2022-03-11-eslint-v8.11.0-released.md
@@ -1,0 +1,67 @@
+---
+layout: post
+title: ESLint v8.11.0 released
+teaser: "We just pushed ESLint v8.11.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+## Highlights
+
+* The [no-unused-vars](/docs/rules/no-unused-vars) rule has a new [`destructuredArrayIgnorePattern`](/docs/rules/no-unused-vars#destructuredarrayignorepattern) option.
+
+
+
+
+
+
+
+## Features
+
+
+* [`800bd25`](https://github.com/eslint/eslint/commit/800bd258e4484de24323809ebbf13fc72fcbabac) feat: add `destructuredArrayIgnorePattern` option in [`no-unused-vars`](/docs/rules/no-unused-vars) ([#15649](https://github.com/eslint/eslint/issues/15649)) (Nitin Kumar)
+* [`8933fe7`](https://github.com/eslint/eslint/commit/8933fe7afcc7cdd99cc0efccc08e8fe3a5e2996f) feat: Catch `undefined` and `Boolean()` in [no-constant-condition](/docs/rules/no-constant-condition) ([#15613](https://github.com/eslint/eslint/issues/15613)) (Jordan Eldredge)
+* [`f90fd9d`](https://github.com/eslint/eslint/commit/f90fd9d779a5b28dfd15ca3f993e6b3cd09e71e8) feat: Add ESLint favicon to the HTML report document ([#15671](https://github.com/eslint/eslint/issues/15671)) (Mahdi Hosseinzadeh)
+* [`57b8a57`](https://github.com/eslint/eslint/commit/57b8a57be75ed2379fe39c93168175090dfe4cdd) feat: [`valid-typeof`](/docs/rules/valid-typeof) always ban `undefined` ([#15635](https://github.com/eslint/eslint/issues/15635)) (Zzzen)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`6814922`](https://github.com/eslint/eslint/commit/68149221637faa8e4f2718773e751126b7ae8ac9) fix: escaping for square brackets in ignore patterns ([#15666](https://github.com/eslint/eslint/issues/15666)) (Milos Djermanovic)
+* [`c178ce7`](https://github.com/eslint/eslint/commit/c178ce7044b5c19db2f4aabfdbe58003db5062fd) fix: extend the autofix range in [comma-dangle](/docs/rules/comma-dangle) to ensure the last element ([#15669](https://github.com/eslint/eslint/issues/15669)) (Milos Djermanovic)
+
+
+
+
+## Documentation
+
+
+* [`c481cec`](https://github.com/eslint/eslint/commit/c481cecacc728618832b4044374e445d332b4381) docs: add fast-eslint-8 to atom integrations (userguide) ([#15695](https://github.com/eslint/eslint/issues/15695)) (db developer)
+* [`d2255db`](https://github.com/eslint/eslint/commit/d2255db24526de604b4a34e90c870158c4ea277e) docs: Add clarification about `eslint-enable` ([#15680](https://github.com/eslint/eslint/issues/15680)) (dosisod)
+* [`8b9433c`](https://github.com/eslint/eslint/commit/8b9433c90c842d8ec06f633df7fbba6ac6d5036b) docs: add object pattern to first section of [computed-property-spacing](/docs/rules/computed-property-spacing) ([#15679](https://github.com/eslint/eslint/issues/15679)) (Milos Djermanovic)
+* [`de800c3`](https://github.com/eslint/eslint/commit/de800c3c0b8e3f85921b40eaa97134fef12effa2) docs: link to minimatch docs added.  ([#15688](https://github.com/eslint/eslint/issues/15688)) (Gaurav Tewari)
+* [`8f675b1`](https://github.com/eslint/eslint/commit/8f675b1f7f6c0591abe36c20410d226bd9e1faa6) docs: [sort-imports](/docs/rules/sort-imports) add single named import example ([#15675](https://github.com/eslint/eslint/issues/15675)) (Arye Eidelman)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`385c9ad`](https://github.com/eslint/eslint/commit/385c9ad685b24b1821ec4085596b3aad299fb751) chore: rm trailing space in docs ([#15689](https://github.com/eslint/eslint/issues/15689)) (唯然)
+
+

--- a/src/content/blog/2022-03-25-eslint-v8.12.0-released.md
+++ b/src/content/blog/2022-03-25-eslint-v8.12.0-released.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: ESLint v8.12.0 released
+teaser: "We just pushed ESLint v8.12.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - btmills
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+
+
+
+
+
+
+
+## Features
+
+
+* [`685a67a`](https://github.com/eslint/eslint/commit/685a67a62bdea19ca9ce12008a034b8d31162422) feat: fix logic for top-level `this` in [no-invalid-this](/docs/rules/no-invalid-this) and [no-eval](/docs/rules/no-eval) ([#15712](https://github.com/eslint/eslint/issues/15712)) (Milos Djermanovic)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`18f5e05`](https://github.com/eslint/eslint/commit/18f5e05bce10503186989d81ca484abb185a2c9d) chore: [padding-line-between-statements](/docs/rules/padding-line-between-statements) remove useless `additionalItems` ([#15706](https://github.com/eslint/eslint/issues/15706)) (Martin Sadovy)
+
+

--- a/src/content/blog/2022-04-08-eslint-v8.13.0-released.md
+++ b/src/content/blog/2022-04-08-eslint-v8.13.0-released.md
@@ -1,0 +1,59 @@
+---
+layout: post
+title: ESLint v8.13.0 released
+teaser: "We just pushed ESLint v8.13.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+
+
+
+
+
+
+
+## Features
+
+
+* [`274acbd`](https://github.com/eslint/eslint/commit/274acbd56537f6b8199da1ac9e7bced74ae81b56) feat: fix [no-eval](/docs/rules/no-eval) logic for `this` in arrow functions ([#15755](https://github.com/eslint/eslint/issues/15755)) (Milos Djermanovic)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`97b57ae`](https://github.com/eslint/eslint/commit/97b57ae3ebae9150456f5516c64b6d2ba75b4038) fix: invalid operator in [operator-assignment](/docs/rules/operator-assignment) messages ([#15759](https://github.com/eslint/eslint/issues/15759)) (Milos Djermanovic)
+
+
+
+
+## Documentation
+
+
+* [`c32482e`](https://github.com/eslint/eslint/commit/c32482e4fd4ad09f3d5fd960dc1fb7c1b4e56f23) docs: Typo in [space-infix-ops](/docs/rules/space-infix-ops) docs  ([#15754](https://github.com/eslint/eslint/issues/15754)) (kmin-jeong)
+* [`f2c2d35`](https://github.com/eslint/eslint/commit/f2c2d350425268efa4b78ee6e0a2df8860e0efad) docs: disambiguate types `FormatterFunction` and `LoadedFormatter` ([#15727](https://github.com/eslint/eslint/issues/15727)) (Francesco Trotta)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`bb4c0d5`](https://github.com/eslint/eslint/commit/bb4c0d530a231a8a14ed70ad61c06e284bbaaef0) chore: Refactor docs to work with docs.eslint.org ([#15744](https://github.com/eslint/eslint/issues/15744)) (Nicholas C. Zakas)
+* [`d36f12f`](https://github.com/eslint/eslint/commit/d36f12f71b3e4f9e9552f1054d7a75be4dc03671) chore: remove `lib/init` from eslint config ([#15748](https://github.com/eslint/eslint/issues/15748)) (Milos Djermanovic)
+* [`a59a4e6`](https://github.com/eslint/eslint/commit/a59a4e6e9217b3cc503c0a702b9e3b02b20b980d) chore: replace `trimLeft`/`trimRight` with `trimStart`/`trimEnd` ([#15750](https://github.com/eslint/eslint/issues/15750)) (Milos Djermanovic)
+
+

--- a/src/content/blog/2022-04-22-eslint-v8.14.0-released.md
+++ b/src/content/blog/2022-04-22-eslint-v8.14.0-released.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: ESLint v8.14.0 released
+teaser: "We just pushed ESLint v8.14.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+## Highlights
+
+* One new rule has been added: [no-constant-binary-expression](/docs/rules/no-constant-binary-expression)
+
+## Features
+
+
+* [`ab6363d`](https://github.com/eslint/eslint/commit/ab6363dffb9dfd9c6a9abb5292fc712745fe7a64) feat: Add rule [no-constant-binary-expression](/docs/rules/no-constant-binary-expression) ([#15296](https://github.com/eslint/eslint/issues/15296)) (Jordan Eldredge)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`35fa1dd`](https://github.com/eslint/eslint/commit/35fa1dd8932ef3e55c37ec0e4b73b5d88f187e69) fix: allow project paths to have URL-encoded characters ([#15795](https://github.com/eslint/eslint/issues/15795)) (Milos Djermanovic)
+* [`413f1d5`](https://github.com/eslint/eslint/commit/413f1d55f0ad05b6fe75bdde6df423253806797d) fix: update `astUtils.isDirectiveComment` with `globals` and `exported` ([#15775](https://github.com/eslint/eslint/issues/15775)) (Milos Djermanovic)
+
+
+
+
+
+
+
+
+## Build Related
+
+
+* [`c2407e8`](https://github.com/eslint/eslint/commit/c2407e81caf2d50325d9aa09bae70d38615ddf2c) build: add node v18 ([#15791](https://github.com/eslint/eslint/issues/15791)) (唯然)
+
+
+
+
+## Chores
+
+
+* [`735458c`](https://github.com/eslint/eslint/commit/735458cc96d4ecdb4ed97448b63ed4a579890b13) chore: add static frontmatter to [no-constant-binary-expression](/docs/rules/no-constant-binary-expression) docs ([#15798](https://github.com/eslint/eslint/issues/15798)) (Milos Djermanovic)
+* [`db28f2c`](https://github.com/eslint/eslint/commit/db28f2c9ea6b654f615daf2f7e6f1a2034b85062) chore: Add static frontmatter to docs ([#15782](https://github.com/eslint/eslint/issues/15782)) (Nicholas C. Zakas)
+* [`3bca59e`](https://github.com/eslint/eslint/commit/3bca59e30de73fb82d4def262ae1df72089df80d) chore: markdownlint autofix on commit ([#15783](https://github.com/eslint/eslint/issues/15783)) (Nicholas C. Zakas)
+
+

--- a/src/content/blog/2022-05-06-eslint-v8.15.0-released.md
+++ b/src/content/blog/2022-05-06-eslint-v8.15.0-released.md
@@ -1,0 +1,73 @@
+---
+layout: post
+title: ESLint v8.15.0 released
+teaser: "We just pushed ESLint v8.15.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+## Highlights
+
+The [no-underscore-dangle](/docs/rules/no-underscore-dangle) rule has a new option `enforceInClassFields`.
+
+
+
+
+
+
+
+## Features
+
+
+* [`ab37d3b`](https://github.com/eslint/eslint/commit/ab37d3ba302856007beb833c34b56658a34bbb5d) feat: add `enforceInClassFields` option to [no-underscore-dangle](/docs/rules/no-underscore-dangle) ([#15818](https://github.com/eslint/eslint/issues/15818)) (Roberto Cestari)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`8bf9440`](https://github.com/eslint/eslint/commit/8bf9440ac47907ffd27aba095428908e7ddeae8a) fix: "use strict" should not trigger strict mode in ES3 ([#15846](https://github.com/eslint/eslint/issues/15846)) (Milos Djermanovic)
+
+
+
+
+## Documentation
+
+
+* [`28116cc`](https://github.com/eslint/eslint/commit/28116ccce4b99da3d5aa9b8994dd3652df7b1cab) docs: update AST node names link in [no-restricted-syntax](/docs/rules/no-restricted-syntax) ([#15843](https://github.com/eslint/eslint/issues/15843)) (Milos Djermanovic)
+* [`272965f`](https://github.com/eslint/eslint/commit/272965feda8adfbf5bfa0e01b37df27ce70fc9fd) docs: fix h1 heading on formatters page ([#15834](https://github.com/eslint/eslint/issues/15834)) (Milos Djermanovic)
+* [`a798166`](https://github.com/eslint/eslint/commit/a7981669fffe33deaf4fbe295f660edc8ccad4cd) docs: update example for running individual rule tests ([#15833](https://github.com/eslint/eslint/issues/15833)) (Milos Djermanovic)
+* [`57e732b`](https://github.com/eslint/eslint/commit/57e732be4e349470fad3e3cc44d96bf0746a598b) docs: mark `SourceCode#getJSDocComment` deprecated in working-with-rules ([#15829](https://github.com/eslint/eslint/issues/15829)) (Milos Djermanovic)
+* [`9a90abf`](https://github.com/eslint/eslint/commit/9a90abf59e31247c03a24ca789cd6157504f63ed) docs: update docs directory in working-with-rules ([#15830](https://github.com/eslint/eslint/issues/15830)) (Milos Djermanovic)
+* [`810adda`](https://github.com/eslint/eslint/commit/810addac9b958c03d69f5f8f21d47ff7fb4c5db6) docs: add more examples for [prefer-object-spread](/docs/rules/prefer-object-spread) ([#15831](https://github.com/eslint/eslint/issues/15831)) (coderaiser)
+* [`06b1edb`](https://github.com/eslint/eslint/commit/06b1edb68f251558601bf68d47e6bbde693089c9) docs: clarify [no-control-regex](/docs/rules/no-control-regex) rule ([#15808](https://github.com/eslint/eslint/issues/15808)) (Milos Djermanovic)
+* [`9ecd42f`](https://github.com/eslint/eslint/commit/9ecd42f36462331a0d697e74323a4d24f0cf02fc) docs: Fixed typo in code comment ([#15812](https://github.com/eslint/eslint/issues/15812)) (Addison G)
+* [`de992b7`](https://github.com/eslint/eslint/commit/de992b7016e3d91092de7748f0375943ad2c77f0) docs: remove links to 2fa document ([#15804](https://github.com/eslint/eslint/issues/15804)) (Milos Djermanovic)
+* [`5222659`](https://github.com/eslint/eslint/commit/52226593974fc7fcb60f1be73b165863b3d1a7fb) docs: fix 'Related Rules' heading in [no-constant-binary-expression](/docs/rules/no-constant-binary-expression) ([#15799](https://github.com/eslint/eslint/issues/15799)) (Milos Djermanovic)
+* [`e70ae81`](https://github.com/eslint/eslint/commit/e70ae8116256e5b69c6eac1ed71c0fa33a8e6d7a) docs: Update README team and sponsors (ESLint Jenkins)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`1ba6a92`](https://github.com/eslint/eslint/commit/1ba6a926eedcfe725900ed95cf029cff02d0355a) chore: upgrade @eslint/eslintrc@1.2.3 ([#15847](https://github.com/eslint/eslint/issues/15847)) (Milos Djermanovic)
+* [`8167aa7`](https://github.com/eslint/eslint/commit/8167aa7d43d00f1a0e8400f73c0dd66798fd4c56) chore: bump version of minimatch due to security issue PRISMA-2022-0039 ([#15774](https://github.com/eslint/eslint/issues/15774)) (Jan Opravil)
+* [`b8995a4`](https://github.com/eslint/eslint/commit/b8995a40087f3a1e4e87c239951f91ddaac73571) chore: Implement docs site ([#15815](https://github.com/eslint/eslint/issues/15815)) (Nicholas C. Zakas)
+* [`6494e3e`](https://github.com/eslint/eslint/commit/6494e3e8916f0a07226bdd8c8f6b2c5f0884bf6b) chore: update link in `codeql-analysis.yml` ([#15817](https://github.com/eslint/eslint/issues/15817)) (Milos Djermanovic)
+* [`36503ec`](https://github.com/eslint/eslint/commit/36503ec8b6fca292be8e584792fc2ad056df4d2f) chore: enable [no-constant-binary-expression](/docs/rules/no-constant-binary-expression) in eslint-config-eslint ([#15807](https://github.com/eslint/eslint/issues/15807)) (唯然)
+
+

--- a/src/content/blog/2022-05-20-eslint-v8.16.0-released.md
+++ b/src/content/blog/2022-05-20-eslint-v8.16.0-released.md
@@ -1,0 +1,71 @@
+---
+layout: post
+title: ESLint v8.16.0 released
+teaser: "We just pushed ESLint v8.16.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+
+## Highlights
+
+* The [no-misleading-character-class](/docs/rules/no-misleading-character-class) rule now provides [suggestions](/docs/developer-guide/working-with-rules#providing-suggestions) for some of the problems reported by this rule.
+
+
+
+
+
+## Features
+
+
+* [`cab0c22`](https://github.com/eslint/eslint/commit/cab0c2287e12561d869dfcfcd1c4e14c9d6d70d5) feat: add Unicode flag suggestion in [no-misleading-character-class](/docs/rules/no-misleading-character-class) ([#15867](https://github.com/eslint/eslint/issues/15867)) (Milos Djermanovic)
+* [`38ae956`](https://github.com/eslint/eslint/commit/38ae9564a41e1d38adad55976565d85c5c981e1d) feat: check Unicode code point escapes in [no-control-regex](/docs/rules/no-control-regex) ([#15862](https://github.com/eslint/eslint/issues/15862)) (Milos Djermanovic)
+* [`ee69cd3`](https://github.com/eslint/eslint/commit/ee69cd30b3551b3adebfd959a44a9a149221946a) feat: Update global variables ([#15871](https://github.com/eslint/eslint/issues/15871)) (Sébastien Règne)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`3f09aab`](https://github.com/eslint/eslint/commit/3f09aab709980ca974b721de474be2dd183409a2) fix: [function-paren-newline](/docs/rules/function-paren-newline) crash on "new new Foo();" ([#15850](https://github.com/eslint/eslint/issues/15850)) (coderaiser)
+
+
+
+
+## Documentation
+
+
+* [`050d5f4`](https://github.com/eslint/eslint/commit/050d5f4e0456ae9a9d769f4306bc0d60058b0898) docs: Static further reading links ([#15890](https://github.com/eslint/eslint/issues/15890)) (Nicholas C. Zakas)
+* [`36287c0`](https://github.com/eslint/eslint/commit/36287c00d56596fbb2672cfe3f9b9dd24b2926da) docs: fix absolute paths in related rules shortcode to work from /docs ([#15892](https://github.com/eslint/eslint/issues/15892)) (Milos Djermanovic)
+* [`90b6990`](https://github.com/eslint/eslint/commit/90b69901efd265fd11425540928793f1387095cc) docs: fix absolute links in rule macro to work from /docs ([#15891](https://github.com/eslint/eslint/issues/15891)) (Milos Djermanovic)
+* [`f437249`](https://github.com/eslint/eslint/commit/f437249a3bedb47155d33ac753b821ae31b814fa) docs: Adjust docs site path prefix ([#15889](https://github.com/eslint/eslint/issues/15889)) (Nicholas C. Zakas)
+* [`6e16025`](https://github.com/eslint/eslint/commit/6e16025e8fbffa0e1d0c977cb4b6eae30a502d9b) docs: update 'Related Rules' and 'Further Reading' in remaining rules ([#15884](https://github.com/eslint/eslint/issues/15884)) (Milos Djermanovic)
+* [`1d39f69`](https://github.com/eslint/eslint/commit/1d39f698a22e2995bbfcf90b6dafd196a173092a) docs: remove confusing examples for [no-mixed-operators](/docs/rules/no-mixed-operators) ([#15875](https://github.com/eslint/eslint/issues/15875)) (Milos Djermanovic)
+* [`3071d76`](https://github.com/eslint/eslint/commit/3071d76772c002bd7b03053be5be54da52c01242) docs: Fix some grammar issues ([#15837](https://github.com/eslint/eslint/issues/15837)) (byodian)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`1768d0d`](https://github.com/eslint/eslint/commit/1768d0de58e10046ed3e54f0fa52be48ba41f12b) chore: upgrade @eslint/eslintrc@1.3.0 ([#15903](https://github.com/eslint/eslint/issues/15903)) (Milos Djermanovic)
+* [`c686e4c`](https://github.com/eslint/eslint/commit/c686e4c4a04525118f5585fd76bdba59dddf3a97) chore: Add deploy workflow for docs site ([#15894](https://github.com/eslint/eslint/issues/15894)) (Nicholas C. Zakas)
+* [`c7894cd`](https://github.com/eslint/eslint/commit/c7894cd433319e09b10a80b260a5398dac0d5dab) chore: enable some rules from eslint-plugin-unicorn internally ([#15878](https://github.com/eslint/eslint/issues/15878)) (Bryan Mishkin)
+* [`ea65cb5`](https://github.com/eslint/eslint/commit/ea65cb5435162ad29559d175e68f5b6d97e6cdcc) chore: upgrade eslint-plugin-eslint-plugin@^4.2.0 ([#15882](https://github.com/eslint/eslint/issues/15882)) (唯然)
+* [`cc29c69`](https://github.com/eslint/eslint/commit/cc29c696a08430fcbf202482306b8c3dbccc0257) chore: Upgrade official GitHub actions to latest versions ([#15880](https://github.com/eslint/eslint/issues/15880)) (Darius Dzien)
+* [`5891c75`](https://github.com/eslint/eslint/commit/5891c7533f500110129fdea7b9b63c8a409da0bd) chore: Refactor rule docs format ([#15869](https://github.com/eslint/eslint/issues/15869)) (Nicholas C. Zakas)
+
+

--- a/src/content/blog/2022-06-03-eslint-v8.17.0-released.md
+++ b/src/content/blog/2022-06-03-eslint-v8.17.0-released.md
@@ -1,0 +1,72 @@
+---
+layout: post
+title: ESLint v8.17.0 released
+teaser: "We just pushed ESLint v8.17.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+
+## Highlights
+
+The [no-use-before-define](/docs/rules/no-use-before-define) rule has a new option `allowNamedExports`.
+
+
+
+## Features
+
+
+* [`55319e1`](https://github.com/eslint/eslint/commit/55319e133f0862a008db3557d7350f154f2c784f) feat: fix [indent](/docs/rules/indent) bug with semicolon-first style ([#15951](https://github.com/eslint/eslint/issues/15951)) (Milos Djermanovic)
+* [`f6d7920`](https://github.com/eslint/eslint/commit/f6d79209821241c8e03c183b5844a024da0efe8a) feat: add `allowNamedExports` option to [no-use-before-define](/docs/rules/no-use-before-define) ([#15953](https://github.com/eslint/eslint/issues/15953)) (Milos Djermanovic)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`54c0953`](https://github.com/eslint/eslint/commit/54c09530c778eb4076d89777165d59db96c9acb5) fix: cleanup typos ([#15939](https://github.com/eslint/eslint/issues/15939)) (Nick Schonning)
+* [`845a7af`](https://github.com/eslint/eslint/commit/845a7af90ce03b383c8f09654ac049fc161dbb9f) fix: typo ocatal -> octal ([#15940](https://github.com/eslint/eslint/issues/15940)) (Nick Schonning)
+
+
+
+
+## Documentation
+
+
+* [`b915018`](https://github.com/eslint/eslint/commit/b9150186bcc0f2732a69ab0ebd83a9b2fb2e6552) docs: Update website UI to latest ([#15944](https://github.com/eslint/eslint/issues/15944)) (Nicholas C. Zakas)
+* [`f0bb609`](https://github.com/eslint/eslint/commit/f0bb6099668f54ae6f444126b90dbb1146248146) docs: Update Exponentiation operator MDN link ([#15960](https://github.com/eslint/eslint/issues/15960)) (Pranjal Jain)
+* [`baa0153`](https://github.com/eslint/eslint/commit/baa01530469ec233fb60380a0960c1550f9d9a45) docs: Use correct past tense "left" instead of "leaved" ([#15950](https://github.com/eslint/eslint/issues/15950)) (Frederik Braun)
+* [`1351a9b`](https://github.com/eslint/eslint/commit/1351a9b875aa32a8961a68457dde03ede9ef7c78) docs: Add Resources section to rule pages ([#15901](https://github.com/eslint/eslint/issues/15901)) (Nicholas C. Zakas)
+* [`68cf0fb`](https://github.com/eslint/eslint/commit/68cf0fb7f645da5d992a5e749fc6c1311d30e75a) docs: cleanup typos ([#15936](https://github.com/eslint/eslint/issues/15936)) (Nick Schonning)
+* [`13b62ae`](https://github.com/eslint/eslint/commit/13b62aeb710a68e5d838a4d3847c487af1ba9520) docs: use-dart-sass instead of node-sass ([#15912](https://github.com/eslint/eslint/issues/15912)) (Deepshika S)
+* [`c81c5d6`](https://github.com/eslint/eslint/commit/c81c5d6ef1ba5808cca95ab965a162802af9b7cc) docs: add social media links ([#15920](https://github.com/eslint/eslint/issues/15920)) (Deepshika S)
+* [`0d6a50b`](https://github.com/eslint/eslint/commit/0d6a50b41f2fe444fd222463adad48473eaf9b7d) docs: fix openjs link ([#15917](https://github.com/eslint/eslint/issues/15917)) (Amaresh  S M)
+* [`54910f5`](https://github.com/eslint/eslint/commit/54910f5a3bf6615f8ac03d33fd26fc1fa6dea21f) docs: display version in mobile view ([#15909](https://github.com/eslint/eslint/issues/15909)) (Amaresh  S M)
+
+
+
+
+
+
+
+
+## Chores
+
+
+* [`da694b9`](https://github.com/eslint/eslint/commit/da694b9d7cb0247541bcabbf943d1289e0e30167) chore: avoid theme flashes ([#15927](https://github.com/eslint/eslint/issues/15927)) (Strek)
+* [`f836743`](https://github.com/eslint/eslint/commit/f836743e95cb8ad3bdd4e88687dbe2f16bfade62) chore: Use build hook for docs deploy ([#15945](https://github.com/eslint/eslint/issues/15945)) (Nicholas C. Zakas)
+* [`ce035e5`](https://github.com/eslint/eslint/commit/ce035e5fac632ba8d4f1860f92465f22d6b44d42) test: cleanup typos ([#15937](https://github.com/eslint/eslint/issues/15937)) (Nick Schonning)
+* [`10249ad`](https://github.com/eslint/eslint/commit/10249ad1a961463b6b347be71c074951ab8e2652) chore: use addEventListener instead of addListener ([#15923](https://github.com/eslint/eslint/issues/15923)) (Amaresh  S M)
+* [`5f5c1fb`](https://github.com/eslint/eslint/commit/5f5c1fb1083573ea511d0dae7913651db0dca772) chore: lint eleventy config file ([#15904](https://github.com/eslint/eslint/issues/15904)) (Milos Djermanovic)
+* [`8513d37`](https://github.com/eslint/eslint/commit/8513d37c725509c9e9ec1dbbc431f20d32632cf3) chore: update Rule typedefs ([#15915](https://github.com/eslint/eslint/issues/15915)) (Milos Djermanovic)
+* [`55534f1`](https://github.com/eslint/eslint/commit/55534f1a7040fad94bb5726759fbb9acb60d1c24) test: ensure [no-restricted-imports](/docs/rules/no-restricted-imports) works with NodeJS imports ([#15907](https://github.com/eslint/eslint/issues/15907)) (Nick Mazuk)
+
+

--- a/src/content/blog/2022-06-17-eslint-v8.18.0-released.md
+++ b/src/content/blog/2022-06-17-eslint-v8.18.0-released.md
@@ -1,0 +1,78 @@
+---
+layout: post
+title: ESLint v8.18.0 released
+teaser: "We just pushed ESLint v8.18.0, which is a minor release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release."
+image: release-notes-minor.png
+authors:
+  - mdjermanovic
+categories:
+  - Release Notes
+tags:
+  - Release
+---
+
+## Highlights
+
+* [Per-rule performance report](/docs/developer-guide/working-with-rules#per-rule-performance) now includes time spent in `create()` of rules. This time is added to the time spent in the listeners.
+
+
+
+
+
+
+## Features
+
+
+* [`a6273b8`](https://github.com/eslint/eslint/commit/a6273b83b103c463937936ef2404575758a7baa4) feat: account for rule creation time in performance reports ([#15982](https://github.com/eslint/eslint/issues/15982)) (Nitin Kumar)
+
+
+
+
+
+
+## Bug Fixes
+
+
+* [`f364d47`](https://github.com/eslint/eslint/commit/f364d47013d146cdea42b27a7b24d105223f5ffe) fix: Make [no-unused-vars](/docs/rules/no-unused-vars) treat for..of loops same as for..in loops ([#15868](https://github.com/eslint/eslint/issues/15868)) (Alex Bass)
+
+
+
+
+## Documentation
+
+
+* [`4871047`](https://github.com/eslint/eslint/commit/4871047dbd0c5ef5e4089425a85ac85dcd9cf263) docs: Update analytics, canonical URL, ads ([#15996](https://github.com/eslint/eslint/issues/15996)) (Nicholas C. Zakas)
+* [`cddad14`](https://github.com/eslint/eslint/commit/cddad1495fbc1750c26330f7aadc6647e2eebac3) docs: Add correct/incorrect containers ([#15998](https://github.com/eslint/eslint/issues/15998)) (Nicholas C. Zakas)
+* [`b04bc6f`](https://github.com/eslint/eslint/commit/b04bc6f1d558d9ad5eb57383a779fec5a170b3d3) docs: Add rules meta info to rule pages ([#15902](https://github.com/eslint/eslint/issues/15902)) (Nicholas C. Zakas)
+* [`1324f10`](https://github.com/eslint/eslint/commit/1324f10ac58d3685fdb656a4fc9d1e5c9d035e42) docs: unify the wording referring to optional exception ([#15893](https://github.com/eslint/eslint/issues/15893)) (Abdelrahman Elkady)
+* [`ad54d02`](https://github.com/eslint/eslint/commit/ad54d0246797cdd849948e7a5d31571c498af7aa) docs: add missing trailing slash to some internal links ([#15991](https://github.com/eslint/eslint/issues/15991)) (Milos Djermanovic)
+* [`df7768e`](https://github.com/eslint/eslint/commit/df7768e16a5ab55da97749bb89ff19f98ce0cc6c) docs: Switch to version-relative URLs ([#15978](https://github.com/eslint/eslint/issues/15978)) (Nicholas C. Zakas)
+* [`21d6479`](https://github.com/eslint/eslint/commit/21d647904dc30f9484b22acdd9243a6d0ecfba38) docs: change some absolute links to relative ([#15970](https://github.com/eslint/eslint/issues/15970)) (Milos Djermanovic)
+* [`f31216a`](https://github.com/eslint/eslint/commit/f31216a90a6204ed1fd56547772376a10f5d3ebb) docs: Update README team and sponsors (ESLint Jenkins)
+
+
+
+
+
+
+## Build Related
+
+
+* [`ed49f15`](https://github.com/eslint/eslint/commit/ed49f15fad96060501927ca27ebda1a4c736ed04) build: remove unwanted parallel and image-min for dev server ([#15986](https://github.com/eslint/eslint/issues/15986)) (Strek)
+
+
+
+
+## Chores
+
+
+* [`f6e2e63`](https://github.com/eslint/eslint/commit/f6e2e632fa3710cfa467b15350b08dea6e0e3dfc) chore: fix 'replaced by' rule list ([#16007](https://github.com/eslint/eslint/issues/16007)) (Milos Djermanovic)
+* [`d94dc84`](https://github.com/eslint/eslint/commit/d94dc84ae76a36b4ee9268c40d8536d2f5b1c63c) chore: remove unused deprecation warnings ([#15994](https://github.com/eslint/eslint/issues/15994)) (Francesco Trotta)
+* [`cdcf11e`](https://github.com/eslint/eslint/commit/cdcf11e457a2455bd8875d78651fec55dd148139) chore: fix versions link ([#15995](https://github.com/eslint/eslint/issues/15995)) (Milos Djermanovic)
+* [`d2a8715`](https://github.com/eslint/eslint/commit/d2a871543a12143fa0ecea13d7508021fd019031) chore: add trailing slash to `pathPrefix` ([#15993](https://github.com/eslint/eslint/issues/15993)) (Milos Djermanovic)
+* [`58a1bf0`](https://github.com/eslint/eslint/commit/58a1bf0de33adb1d54c8051090f01984daa08c86) chore: tweak URL rewriting for local previews ([#15992](https://github.com/eslint/eslint/issues/15992)) (Milos Djermanovic)
+* [`80404d2`](https://github.com/eslint/eslint/commit/80404d28f040df49706ba2c1e954aee945711aa9) chore: remove docs deploy workflow ([#15984](https://github.com/eslint/eslint/issues/15984)) (Nicholas C. Zakas)
+* [`71bc750`](https://github.com/eslint/eslint/commit/71bc75012b1377d3c7e57deea0ad06f99c4c65bf) chore: Set permissions for GitHub actions ([#15971](https://github.com/eslint/eslint/issues/15971)) (Naveen)
+* [`90ff647`](https://github.com/eslint/eslint/commit/90ff64742ede6ef29018cb967fc4f20d7b85b592) chore: avoid generating subdirectories for each page on new docs site ([#15967](https://github.com/eslint/eslint/issues/15967)) (Milos Djermanovic)
+
+


### PR DESCRIPTION
Synchronizes the blog posts with the current website and adds `eslintbot` into the `all_authors.json` file so we can use that as a placeholder wherever we want.